### PR TITLE
Add configuration system with JSON5 support and default command

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,4 +51,20 @@ sprout create --linear [ticket-id]
 
 ## Configuration
 
+Sprout supports configuration via `~/.sprout.json5` for customizing behavior:
+
+```json5
+{
+  // Command to run when sprout is called without arguments
+  // If not specified, defaults to interactive mode
+  "defaultCommand": "echo 'Welcome to Sprout!'"
+}
+```
+
+### Configuration Options
+
+- **`defaultCommand`**: Command to execute when `sprout` is called without arguments. If not specified, launches interactive mode.
+
+### Linear Integration
+
 Linear integration requires API token configuration. See [Configuration Guide](docs/configuration.md) for setup details.

--- a/cmd/sprout/main.go
+++ b/cmd/sprout/main.go
@@ -6,11 +6,39 @@ import (
 	"os/exec"
 	"syscall"
 	
+	"sprout/pkg/config"
 	"sprout/pkg/git"
 )
 
 func main() {
+	cfg, err := config.Load()
+	if err != nil {
+		fmt.Printf("Warning: Failed to load config: %v\n", err)
+		cfg = config.DefaultConfig()
+	}
+
 	if len(os.Args) < 2 {
+		// Check if there's a default command configured
+		defaultCmd := cfg.GetDefaultCommand()
+		if len(defaultCmd) > 0 {
+			// Execute the default command
+			cmd := exec.Command(defaultCmd[0], defaultCmd[1:]...)
+			cmd.Stdin = os.Stdin
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			
+			if err := cmd.Run(); err != nil {
+				if exitError, ok := err.(*exec.ExitError); ok {
+					if status, ok := exitError.Sys().(syscall.WaitStatus); ok {
+						os.Exit(status.ExitStatus())
+					}
+				}
+				fmt.Printf("Default command failed: %v\n", err)
+				os.Exit(1)
+			}
+			return
+		}
+		
 		// Interactive mode
 		fmt.Println("Starting Sprout in interactive mode...")
 		// TODO: Launch TUI

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module sprout
 
 go 1.24.2
+
+require github.com/yosuke-furukawa/json5 v0.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/yosuke-furukawa/json5 v0.1.1 h1:0F9mNwTvOuDNH243hoPqvf+dxa5QsKnZzU20uNsh3ZI=
+github.com/yosuke-furukawa/json5 v0.1.1/go.mod h1:sw49aWDqNdRJ6DYUtIQiaA3xyj2IL9tjeNYmX2ixwcU=

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1,0 +1,95 @@
+package config
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/yosuke-furukawa/json5/encoding/json5"
+)
+
+type Config struct {
+	DefaultCommand string `json:"defaultCommand,omitempty"`
+}
+
+func DefaultConfig() *Config {
+	return &Config{
+		DefaultCommand: "",
+	}
+}
+
+func Load() (*Config, error) {
+	configPath, err := getConfigPath()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get config path: %w", err)
+	}
+
+	config := DefaultConfig()
+
+	file, err := os.Open(configPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return config, nil
+		}
+		return nil, fmt.Errorf("failed to open config file: %w", err)
+	}
+	defer file.Close()
+
+	data, err := io.ReadAll(file)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read config file: %w", err)
+	}
+
+	if err := json5.Unmarshal(data, config); err != nil {
+		return nil, fmt.Errorf("failed to parse config file: %w", err)
+	}
+
+	return config, nil
+}
+
+func Save(config *Config) error {
+	configPath, err := getConfigPath()
+	if err != nil {
+		return fmt.Errorf("failed to get config path: %w", err)
+	}
+
+	configDir := filepath.Dir(configPath)
+	if err := os.MkdirAll(configDir, 0755); err != nil {
+		return fmt.Errorf("failed to create config directory: %w", err)
+	}
+
+	data, err := json.MarshalIndent(config, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal config: %w", err)
+	}
+
+	if err := os.WriteFile(configPath, data, 0644); err != nil {
+		return fmt.Errorf("failed to write config file: %w", err)
+	}
+
+	return nil
+}
+
+func getConfigPath() (string, error) {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(homeDir, ".sprout.json5"), nil
+}
+
+func (c *Config) GetDefaultCommand() []string {
+	if c.DefaultCommand == "" {
+		return nil
+	}
+
+	parts := strings.Fields(c.DefaultCommand)
+	if len(parts) == 0 {
+		return nil
+	}
+
+	return parts
+}


### PR DESCRIPTION
## Summary
• Implements configuration loading from `~/.sprout.json5` with JSON5 format support
• Adds `defaultCommand` configuration option to execute when no arguments provided
• Updates main.go to check for and execute default command before falling back to interactive mode
• Graceful error handling for missing or invalid config files

🤖 Generated with [Claude Code](https://claude.ai/code)