### PR TITLE
Add list command with PR status integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Sprout simplifies git worktree management by providing both interactive and comm
 ## Features
 
 ### Git Worktree Management
+- **List existing worktrees**: View all worktrees with branch names, PR status, and commit information
 - **Create worktrees from any location**: Generate new worktrees from the current repository, regardless of which worktree you're currently in
 - **Flexible branch naming**: Optionally specify branch names or let Linear integration handle it automatically
 - **Intelligent input parsing**: Enter as much or as little information as you want - Sprout figures out the rest
@@ -36,6 +37,9 @@ Sprout simplifies git worktree management by providing both interactive and comm
 # Interactive mode
 sprout
 
+# List all worktrees with PR status
+sprout list
+
 # One-shot worktree creation
 sprout create [branch-name]
 
@@ -47,6 +51,7 @@ sprout create --linear [ticket-id]
 
 - Go 1.21+
 - Git 2.5+ (for worktree support)
+- GitHub CLI (`gh`) for PR status information
 - Linear API access (for Linear integration features)
 
 ## Configuration

--- a/pkg/github/pr.go
+++ b/pkg/github/pr.go
@@ -1,0 +1,55 @@
+package github
+
+import (
+	"encoding/json"
+	"os/exec"
+)
+
+type PR struct {
+	State string `json:"state"`
+	Title string `json:"title"`
+}
+
+type Client struct {
+	repoRoot string
+}
+
+func NewClient(repoRoot string) *Client {
+	return &Client{
+		repoRoot: repoRoot,
+	}
+}
+
+func (c *Client) GetPRStatus(branchName string) string {
+	if branchName == "" || branchName == "master" || branchName == "main" {
+		return "-"
+	}
+	
+	cmd := exec.Command("gh", "pr", "list", "--head", branchName, "--json", "state", "--limit", "1")
+	cmd.Dir = c.repoRoot
+	
+	output, err := cmd.Output()
+	if err != nil {
+		return "-"
+	}
+	
+	var prs []PR
+	if err := json.Unmarshal(output, &prs); err != nil {
+		return "-"
+	}
+	
+	if len(prs) == 0 {
+		return "No PR"
+	}
+	
+	switch prs[0].State {
+	case "OPEN":
+		return "Open"
+	case "MERGED":
+		return "Merged"
+	case "CLOSED":
+		return "Closed"
+	default:
+		return prs[0].State
+	}
+}


### PR DESCRIPTION
## Summary
- Add `sprout list` command to display all worktrees with PR status
- Show branch names, PR status (Open/Merged/Closed/No PR), and commit hashes
- Filter out master/main branches for cleaner output
- Integrate with GitHub CLI (`gh`) for PR status checking

## Changes
- Extended `WorktreeManager` with `ListWorktrees()` method
- Added `Worktree` struct with PR status field  
- Implemented GitHub CLI integration for PR status lookup
- Added `handleListCommand()` to main CLI parsing
- Updated README with new command documentation
- Added `gh` CLI requirement to dependencies

🤖 Generated with [Claude Code](https://claude.ai/code)