### PR TITLE
Fix interactive TUI to wait for input before executing default command

### DIFF
--- a/cmd/sprout/main.go
+++ b/cmd/sprout/main.go
@@ -20,27 +20,6 @@ func main() {
 	}
 
 	if len(os.Args) < 2 {
-		// Check if there's a default command configured
-		defaultCmd := cfg.GetDefaultCommand()
-		if len(defaultCmd) > 0 {
-			// Execute the default command
-			cmd := exec.Command(defaultCmd[0], defaultCmd[1:]...)
-			cmd.Stdin = os.Stdin
-			cmd.Stdout = os.Stdout
-			cmd.Stderr = os.Stderr
-			
-			if err := cmd.Run(); err != nil {
-				if exitError, ok := err.(*exec.ExitError); ok {
-					if status, ok := exitError.Sys().(syscall.WaitStatus); ok {
-						os.Exit(status.ExitStatus())
-					}
-				}
-				fmt.Printf("Default command failed: %v\n", err)
-				os.Exit(1)
-			}
-			return
-		}
-		
 		// Interactive mode
 		if err := ui.RunInteractive(); err != nil {
 			fmt.Printf("Error: %v\n", err)


### PR DESCRIPTION
## Summary
- Fixed interactive TUI mode to properly wait for branch name input instead of immediately executing default command
- Resolved terminal state issues when default command is an interactive shell
- TUI now cleanly exits before executing default command in worktree directory

## Changes
- **cmd/sprout/main.go**: Removed premature default command execution, now always starts interactive mode when no args provided
- **pkg/ui/tui.go**: Modified to store worktree path and execute default command after TUI exits cleanly

🤖 Generated with [Claude Code](https://claude.ai/code)