### PR TITLE
Add shell script wrapper for convenient execution

### DIFF
--- a/sprout
+++ b/sprout
@@ -1,0 +1,2 @@
+#!/bin/bash
+exec go run ./cmd/sprout "$@"


### PR DESCRIPTION
## Summary
- Adds executable shell script `sprout` that wraps `go run ./cmd/sprout`
- Allows running `./sprout` instead of `go run ./cmd/sprout`
- Script properly forwards all arguments using `"$@"`

🤖 Generated with [Claude Code](https://claude.ai/code)