### PR TITLE
Add Linear API key configuration support

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,14 +62,27 @@ Sprout supports configuration via `~/.sprout.json5` for customizing behavior:
 {
   // Command to run when sprout is called without arguments
   // If not specified, defaults to interactive mode
-  "defaultCommand": "echo 'Welcome to Sprout!'"
+  "defaultCommand": "echo 'Welcome to Sprout!'",
+  
+  // Linear API key for ticket integration
+  "linearApiKey": "your-linear-api-key-here"
 }
 ```
 
 ### Configuration Options
 
 - **`defaultCommand`**: Command to execute when `sprout` is called without arguments. If not specified, launches interactive mode.
+- **`linearApiKey`**: Your Linear API key for accessing tickets and creating branches from Linear issues.
 
 ### Linear Integration
 
-Linear integration requires API token configuration. See [Configuration Guide](docs/configuration.md) for setup details.
+To use Linear integration features, you'll need to:
+
+1. Get your Linear API key from [Linear Settings > API](https://linear.app/settings/api)
+2. Add it to your `~/.sprout.json5` configuration file
+3. Run `sprout doctor` to verify the configuration is working
+
+The Linear API key enables:
+- Browsing and selecting tickets for worktree creation
+- Automatic branch name suggestions based on ticket titles
+- Creating subtasks directly from the terminal UI

--- a/cmd/sprout/main.go
+++ b/cmd/sprout/main.go
@@ -168,6 +168,12 @@ func handleDoctorCommand(cfg *config.Config) {
 	fmt.Println("===================")
 	fmt.Printf("Default Command: %s\n", cfg.DefaultCommand)
 	
+	if cfg.GetLinearAPIKey() != "" {
+		fmt.Printf("Linear API Key: configured\n")
+	} else {
+		fmt.Printf("Linear API Key: not configured\n")
+	}
+	
 	configPath, err := getConfigPath()
 	if err != nil {
 		fmt.Printf("Config Path: <error: %v>\n", err)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -13,11 +13,13 @@ import (
 
 type Config struct {
 	DefaultCommand string `json:"defaultCommand,omitempty"`
+	LinearAPIKey   string `json:"linearApiKey,omitempty"`
 }
 
 func DefaultConfig() *Config {
 	return &Config{
 		DefaultCommand: "",
+		LinearAPIKey:   "",
 	}
 }
 
@@ -92,4 +94,8 @@ func (c *Config) GetDefaultCommand() []string {
 	}
 
 	return parts
+}
+
+func (c *Config) GetLinearAPIKey() string {
+	return c.LinearAPIKey
 }


### PR DESCRIPTION
## Summary

- Add `linearApiKey` field to the Config struct for storing Linear API credentials
- Update `sprout doctor` command to show Linear API key configuration status
- Add documentation for Linear API key setup in README

## Changes

- **Config struct**: Added `LinearAPIKey` field with JSON serialization support
- **Doctor command**: Shows whether Linear API key is configured (without exposing the actual key)
- **README**: Updated with Linear API key configuration instructions and setup guide

This enables future Linear integration features while providing users with clear configuration guidance.

🤖 Generated with [Claude Code](https://claude.ai/code)