### PR TITLE
Print worktree directory after command execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,9 +43,30 @@ sprout list
 # One-shot worktree creation
 sprout create [branch-name]
 
+# Create worktree and run command in it
+sprout create [branch-name] [command] [args...]
+
 # One-shot with Linear ticket
 sprout create --linear [ticket-id]
 ```
+
+### Command Examples
+
+```bash
+# Create worktree and change to it
+cd "$(sprout create mybranch)"
+
+# Create worktree and open in VS Code
+sprout create mybranch code .
+
+# Create worktree and start a shell
+sprout create mybranch bash
+
+# Create worktree and run git status
+sprout create mybranch git status
+```
+
+**Note**: When running commands with `sprout create`, the worktree directory is printed to stderr after command execution for easy reference.
 
 ## Requirements
 

--- a/cmd/sprout/main.go
+++ b/cmd/sprout/main.go
@@ -91,11 +91,13 @@ func handleCreateCommand(args []string) error {
 			if err := cmd.Run(); err != nil {
 				if exitError, ok := err.(*exec.ExitError); ok {
 					if status, ok := exitError.Sys().(syscall.WaitStatus); ok {
+						fmt.Fprintf(os.Stderr, "\nWorktree directory: %s\n", worktreePath)
 						os.Exit(status.ExitStatus())
 					}
 				}
 				return fmt.Errorf("default command failed: %w", err)
 			}
+			fmt.Fprintf(os.Stderr, "\nWorktree directory: %s\n", worktreePath)
 			return nil
 		}
 		
@@ -117,12 +119,14 @@ func handleCreateCommand(args []string) error {
 	if err := cmd.Run(); err != nil {
 		if exitError, ok := err.(*exec.ExitError); ok {
 			if status, ok := exitError.Sys().(syscall.WaitStatus); ok {
+				fmt.Fprintf(os.Stderr, "\nWorktree directory: %s\n", worktreePath)
 				os.Exit(status.ExitStatus())
 			}
 		}
 		return fmt.Errorf("command failed: %w", err)
 	}
 	
+	fmt.Fprintf(os.Stderr, "\nWorktree directory: %s\n", worktreePath)
 	return nil
 }
 


### PR DESCRIPTION
## Summary
- Added feature to print worktree directory to stderr after command execution
- Works for both successful and failed commands
- Updated README with documentation about this behavior

This enhancement makes it easier for users to find their worktree after running commands, especially useful when starting shells or other interactive processes.

🤖 Generated with [Claude Code](https://claude.ai/code)