### PR TITLE
Add config validation for unrecognized keys

### DIFF
--- a/cmd/sprout/main.go
+++ b/cmd/sprout/main.go
@@ -16,8 +16,8 @@ import (
 func main() {
 	cfg, err := config.Load()
 	if err != nil {
-		fmt.Printf("Warning: Failed to load config: %v\n", err)
-		cfg = config.DefaultConfig()
+		fmt.Printf("Error: Failed to load config: %v\n", err)
+		os.Exit(1)
 	}
 
 	if len(os.Args) < 2 {
@@ -76,8 +76,7 @@ func handleCreateCommand(args []string) error {
 	if len(args) == 1 {
 		cfg, err := config.Load()
 		if err != nil {
-			fmt.Printf("Warning: Failed to load config: %v\n", err)
-			cfg = config.DefaultConfig()
+			return fmt.Errorf("failed to load config: %w", err)
 		}
 		
 		defaultCmd := cfg.GetDefaultCommand()


### PR DESCRIPTION
## Summary
- Add validation to detect unrecognized config keys in .sprout.json5
- Exit with error when invalid config keys are found
- Display helpful error message showing valid config options

## Changes
- Modified `pkg/config/config.go` to validate config keys before parsing into struct
- Updated error handling in `cmd/sprout/main.go` to treat config errors as fatal
- Added descriptive error messages listing valid config keys

🤖 Generated with [Claude Code](https://claude.ai/code)