### PR TITLE
Add recursive sub-issue expansion for Linear tasks

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,13 +4,13 @@ go 1.24.2
 
 require (
 	github.com/charmbracelet/bubbletea v1.3.6
+	github.com/charmbracelet/lipgloss v1.1.0
 	github.com/yosuke-furukawa/json5 v0.1.1
 )
 
 require (
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
 	github.com/charmbracelet/colorprofile v0.2.3-0.20250311203215-f60798e515dc // indirect
-	github.com/charmbracelet/lipgloss v1.1.0 // indirect
 	github.com/charmbracelet/x/ansi v0.9.3 // indirect
 	github.com/charmbracelet/x/cellbuf v0.0.13-0.20250311204145-2c3ea96c31dd // indirect
 	github.com/charmbracelet/x/term v0.2.1 // indirect


### PR DESCRIPTION
## Summary
- Implemented right arrow key (→) expansion for Linear sub-issues
- Added recursive navigation through task hierarchies with proper indentation
- Sub-issues are dynamically fetched from Linear API when first expanded
- Enhanced UI with visual indicators (▶/▼) for expandable items

## Features
- **Right Arrow Expansion**: Press → on any Linear task to expand/collapse its sub-issues
- **Recursive Navigation**: Navigate seamlessly through parent tasks and sub-issues using ↑/↓
- **Visual Hierarchy**: Sub-issues are indented (2 spaces per level) with clear expansion indicators
- **Dynamic Loading**: Sub-issues are fetched from Linear API only when needed
- **Full Selection**: All sub-issues are selectable for worktree creation

## Technical Implementation
- Extended `Issue` struct with children, parent, and expansion state tracking
- Added `GetIssueChildren()` method to Linear client for GraphQL sub-issue queries  
- Implemented flattened navigation structure for smooth keyboard navigation
- Added helper functions for recursive issue expansion/collapse management
- Enhanced TUI rendering with proper indentation and visual indicators

🤖 Generated with [Claude Code](https://claude.ai/code)