### PR TITLE
Remove limit on Linear ticket display

### DIFF
--- a/pkg/linear/client.go
+++ b/pkg/linear/client.go
@@ -176,7 +176,6 @@ func (c *Client) GetAssignedIssues() ([]Issue, error) {
 					state: { type: { neq: "completed" } }
 				}
 				orderBy: updatedAt
-				first: 10
 			) {
 				nodes {
 					id


### PR DESCRIPTION
## Summary
- Remove hardcoded `first: 10` limit from GetAssignedIssues GraphQL query
- Now displays all assigned Linear tickets regardless of quantity  
- Users can scroll through all tickets in the UI

🤖 Generated with [Claude Code](https://claude.ai/code)