### PR TITLE
Make TUI responsive to terminal width for better text display

### DIFF
--- a/features/window_width.feature
+++ b/features/window_width.feature
@@ -1,0 +1,28 @@
+Feature: Window Width Responsive Layout
+  As a developer using Sprout
+  I want the TUI to use the full width of my terminal
+  So that long ticket names and branch names are not unnecessarily truncated
+
+  Background:
+    Given the following Linear issues exist:
+      | identifier | title                                                              | parent_id |
+      | SPR-123    | Add user authentication                                            |           |
+      | SPR-124    | Implement comprehensive dashboard with advanced analytics and detailed reporting capabilities |           |
+      | SPR-125    | Create analytics component with real-time data visualization      | SPR-124   |
+
+  Scenario: Wide terminal shows full titles
+    Given my terminal width is 120 characters
+    When I start the Sprout TUI
+    Then the UI should display:
+      """
+      🌱 sprout
+
+      > sprout/enter branch name or select suggestion below
+      ├──SPR-123  Add user authentication
+      └──SPR-124  Implement comprehensive dashboard with advanced analytics and detailed reporting capabilities
+      """
+
+  Scenario: Narrow terminal truncates appropriately
+    Given my terminal width is 60 characters
+    When I start the Sprout TUI
+    Then the UI should display titles truncated to fit the available width


### PR DESCRIPTION
## Summary

- Fixed ticket names and branch names being truncated too early by making the TUI responsive to terminal width
- Replaced hardcoded 50-character limit with dynamic calculation based on available space
- Added comprehensive BDD tests to ensure proper behavior across different terminal widths

## Changes

### Core Improvements
- **Dynamic Title Truncation**: Calculate available width based on terminal size, identifier length, tree depth, and margins
- **Responsive Text Input**: Adjust input field width to use most of the terminal width while leaving space for prompt and margins  
- **Window Size Handling**: Listen for terminal resize events and update layout accordingly

### Testing
- Added `window_width.feature` with scenarios for both wide and narrow terminals
- Enhanced BDD test framework with terminal width configuration support
- All existing tests continue to pass

### Key Benefits
- Long ticket titles now display fully on wide terminals instead of being unnecessarily truncated
- Graceful truncation with "..." when space is actually limited
- Better utilization of available screen real estate
- Responsive behavior when terminal is resized

🤖 Generated with [Claude Code](https://claude.ai/code)