### PR TITLE
Ensure worktrees are always created from master/main branch

### DIFF
--- a/pkg/git/worktree_test.go
+++ b/pkg/git/worktree_test.go
@@ -1,0 +1,229 @@
+package git
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestGetBaseBranch(t *testing.T) {
+	// Create a temporary git repository for testing
+	tempDir, err := os.MkdirTemp("", "sprout-test-*")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	// Initialize git repo
+	cmd := exec.Command("git", "init")
+	cmd.Dir = tempDir
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("Failed to init git repo: %v", err)
+	}
+
+	// Create initial commit
+	testFile := filepath.Join(tempDir, "README.md")
+	if err := os.WriteFile(testFile, []byte("# Test"), 0644); err != nil {
+		t.Fatalf("Failed to create test file: %v", err)
+	}
+
+	cmd = exec.Command("git", "add", ".")
+	cmd.Dir = tempDir
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("Failed to add files: %v", err)
+	}
+
+	cmd = exec.Command("git", "commit", "-m", "Initial commit")
+	cmd.Dir = tempDir
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("Failed to commit: %v", err)
+	}
+
+	wm := &WorktreeManager{repoRoot: tempDir}
+
+	t.Run("main branch exists", func(t *testing.T) {
+		// Rename branch to main
+		cmd := exec.Command("git", "branch", "-m", "main")
+		cmd.Dir = tempDir
+		if err := cmd.Run(); err != nil {
+			t.Fatalf("Failed to rename branch: %v", err)
+		}
+
+		branch, err := wm.getBaseBranch()
+		if err != nil {
+			t.Errorf("Expected no error, got: %v", err)
+		}
+		if branch != "main" {
+			t.Errorf("Expected 'main', got '%s'", branch)
+		}
+	})
+
+	t.Run("master branch exists", func(t *testing.T) {
+		// Rename branch to master
+		cmd := exec.Command("git", "branch", "-m", "master")
+		cmd.Dir = tempDir
+		if err := cmd.Run(); err != nil {
+			t.Fatalf("Failed to rename branch: %v", err)
+		}
+
+		branch, err := wm.getBaseBranch()
+		if err != nil {
+			t.Errorf("Expected no error, got: %v", err)
+		}
+		if branch != "master" {
+			t.Errorf("Expected 'master', got '%s'", branch)
+		}
+	})
+
+	t.Run("remote main exists", func(t *testing.T) {
+		// Create a bare repo to act as remote
+		remoteDir, err := os.MkdirTemp("", "sprout-remote-*")
+		if err != nil {
+			t.Fatalf("Failed to create remote dir: %v", err)
+		}
+		defer os.RemoveAll(remoteDir)
+
+		cmd := exec.Command("git", "init", "--bare")
+		cmd.Dir = remoteDir
+		if err := cmd.Run(); err != nil {
+			t.Fatalf("Failed to init bare repo: %v", err)
+		}
+
+		// Add remote
+		cmd = exec.Command("git", "remote", "add", "origin", remoteDir)
+		cmd.Dir = tempDir
+		if err := cmd.Run(); err != nil {
+			t.Fatalf("Failed to add remote: %v", err)
+		}
+
+		// Push current branch as main
+		cmd = exec.Command("git", "push", "-u", "origin", "master:main")
+		cmd.Dir = tempDir
+		if err := cmd.Run(); err != nil {
+			t.Fatalf("Failed to push: %v", err)
+		}
+
+		// Delete local branch
+		cmd = exec.Command("git", "checkout", "--detach")
+		cmd.Dir = tempDir
+		if err := cmd.Run(); err != nil {
+			t.Fatalf("Failed to detach HEAD: %v", err)
+		}
+
+		cmd = exec.Command("git", "branch", "-D", "master")
+		cmd.Dir = tempDir
+		if err := cmd.Run(); err != nil {
+			t.Fatalf("Failed to delete branch: %v", err)
+		}
+
+		branch, err := wm.getBaseBranch()
+		if err != nil {
+			t.Errorf("Expected no error, got: %v", err)
+		}
+		if branch != "origin/main" {
+			t.Errorf("Expected 'origin/main', got '%s'", branch)
+		}
+	})
+}
+
+func TestCreateWorktreeFromBase(t *testing.T) {
+	// Create a temporary git repository for testing
+	tempDir, err := os.MkdirTemp("", "sprout-test-*")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	// Initialize git repo
+	cmd := exec.Command("git", "init")
+	cmd.Dir = tempDir
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("Failed to init git repo: %v", err)
+	}
+
+	// Create initial commit on master
+	testFile := filepath.Join(tempDir, "README.md")
+	if err := os.WriteFile(testFile, []byte("# Test"), 0644); err != nil {
+		t.Fatalf("Failed to create test file: %v", err)
+	}
+
+	cmd = exec.Command("git", "add", ".")
+	cmd.Dir = tempDir
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("Failed to add files: %v", err)
+	}
+
+	cmd = exec.Command("git", "commit", "-m", "Initial commit")
+	cmd.Dir = tempDir
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("Failed to commit: %v", err)
+	}
+
+	// Get the master commit hash
+	cmd = exec.Command("git", "rev-parse", "HEAD")
+	cmd.Dir = tempDir
+	masterCommitBytes, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("Failed to get master commit: %v", err)
+	}
+	masterCommit := strings.TrimSpace(string(masterCommitBytes))
+
+	// Create another branch with a different commit
+	cmd = exec.Command("git", "checkout", "-b", "feature-branch")
+	cmd.Dir = tempDir
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("Failed to create feature branch: %v", err)
+	}
+
+	// Make another commit on feature branch
+	if err := os.WriteFile(testFile, []byte("# Test\n\nFeature content"), 0644); err != nil {
+		t.Fatalf("Failed to update test file: %v", err)
+	}
+
+	cmd = exec.Command("git", "add", ".")
+	cmd.Dir = tempDir
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("Failed to add files: %v", err)
+	}
+
+	cmd = exec.Command("git", "commit", "-m", "Feature commit")
+	cmd.Dir = tempDir
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("Failed to commit: %v", err)
+	}
+
+	// Now create a worktree - it should be based on master, not feature-branch
+	wm := &WorktreeManager{repoRoot: tempDir}
+	worktreePath, err := wm.CreateWorktree("test-worktree")
+	if err != nil {
+		t.Fatalf("Failed to create worktree: %v", err)
+	}
+
+	// Check that the worktree is based on master commit
+	cmd = exec.Command("git", "rev-parse", "HEAD")
+	cmd.Dir = worktreePath
+	worktreeCommitBytes, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("Failed to get worktree commit: %v", err)
+	}
+	worktreeCommit := strings.TrimSpace(string(worktreeCommitBytes))
+
+	if worktreeCommit != masterCommit {
+		t.Errorf("Expected worktree to be based on master commit %s, but got %s", masterCommit, worktreeCommit)
+	}
+
+	// Verify the branch exists
+	cmd = exec.Command("git", "branch", "--show-current")
+	cmd.Dir = worktreePath
+	branchBytes, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("Failed to get current branch: %v", err)
+	}
+	currentBranch := strings.TrimSpace(string(branchBytes))
+
+	if currentBranch != "test-worktree" {
+		t.Errorf("Expected branch to be 'test-worktree', got '%s'", currentBranch)
+	}
+}


### PR DESCRIPTION
## Summary
- Added `getBaseBranch()` method to determine the appropriate base branch (main or master)
- Modified `createNormalWorktree()` and `createSparseWorktree()` to use the base branch when creating new worktrees
- Added comprehensive tests to verify the new behavior

## Details
Previously, worktrees were created from the current HEAD position, which could lead to inconsistent base branches if the user was on a feature branch. This change ensures all new worktrees are consistently branched from either the `main` or `master` branch.

The implementation:
1. First checks for local `main` branch
2. Falls back to local `master` branch if `main` doesn't exist
3. Checks for remote `origin/main` if no local branches found
4. Finally checks for remote `origin/master`
5. Returns an error if none of these branches exist

🤖 Generated with [Claude Code](https://claude.ai/code)