### PR TITLE
Fix quoted arguments in defaultCommand configuration

### DIFF
--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1,0 +1,77 @@
+package config
+
+import (
+	"testing"
+)
+
+func TestGetDefaultCommand(t *testing.T) {
+	tests := []struct {
+		name           string
+		defaultCommand string
+		expected       []string
+	}{
+		{
+			name:           "empty command",
+			defaultCommand: "",
+			expected:       nil,
+		},
+		{
+			name:           "simple command",
+			defaultCommand: "bash",
+			expected:       []string{"bash"},
+		},
+		{
+			name:           "command with args",
+			defaultCommand: "npm run dev",
+			expected:       []string{"npm", "run", "dev"},
+		},
+		{
+			name:           "command with quoted string argument",
+			defaultCommand: `run_thing "with a string arg"`,
+			expected:       []string{"run_thing", "with a string arg"},
+		},
+		{
+			name:           "command with single quotes",
+			defaultCommand: `echo 'hello world'`,
+			expected:       []string{"echo", "hello world"},
+		},
+		{
+			name:           "command with multiple quoted arguments",
+			defaultCommand: `script "first arg" "second arg" third`,
+			expected:       []string{"script", "first arg", "second arg", "third"},
+		},
+		{
+			name:           "command with escaped quotes",
+			defaultCommand: `echo "hello \"world\""`,
+			expected:       []string{"echo", `hello "world"`},
+		},
+		{
+			name:           "complex command with flags and quoted args",
+			defaultCommand: `docker run -it --name "my container" ubuntu:latest`,
+			expected:       []string{"docker", "run", "-it", "--name", "my container", "ubuntu:latest"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &Config{
+				DefaultCommand: tt.defaultCommand,
+			}
+			
+			result := cfg.GetDefaultCommand()
+			
+			if len(result) != len(tt.expected) {
+				t.Errorf("GetDefaultCommand() returned %d args, expected %d", len(result), len(tt.expected))
+				t.Errorf("Got: %v", result)
+				t.Errorf("Expected: %v", tt.expected)
+				return
+			}
+			
+			for i, arg := range result {
+				if arg != tt.expected[i] {
+					t.Errorf("GetDefaultCommand() arg[%d] = %q, expected %q", i, arg, tt.expected[i])
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Fixed bug where quoted arguments in `defaultCommand` were incorrectly split
- Added proper shell-like parsing that respects quotes and escape sequences
- Added comprehensive test coverage for the parsing logic

## Details

When users configure `defaultCommand` in their settings with quoted arguments like:
```json
{
  "defaultCommand": "run_thing \"with a string arg\""
}
```

The command was incorrectly split using `strings.Fields()`, resulting in each word becoming a separate argument. This fix implements a proper command-line parser that:
- Respects both single and double quotes
- Handles escaped characters within quotes
- Maintains backward compatibility with simple commands

🤖 Generated with [Claude Code](https://claude.ai/code)