### PR TITLE
Fix backspace handling in search mode

### DIFF
--- a/features/search.feature
+++ b/features/search.feature
@@ -125,3 +125,52 @@ Feature: Sprout TUI Fuzzy Search
       ├──SPR-123  Add user authentication
       └──SPR-128  Update user profile settings
       """
+
+  Scenario: Backspace works in search mode
+    Given I start the Sprout TUI
+    And I press "/"
+    And I type "auth"
+    When I press "backspace"
+    Then the UI should display:
+      """
+      🌱 sprout
+
+      /aut
+      ├──SPR-123  Add user authentication
+      ├──SPR-127  Fix critical bug in payment processing
+      └──SPR-128  Update user profile settings
+      """
+    When I press "backspace"
+    Then the UI should display:
+      """
+      🌱 sprout
+
+      /au
+      ├──SPR-123  Add user authentication
+      ├──SPR-127  Fix critical bug in payment processing
+      └──SPR-128  Update user profile settings
+      """
+    When I press "backspace"
+    Then the UI should display:
+      """
+      🌱 sprout
+
+      /a
+      ├──SPR-123  Add user authentication
+      ├──SPR-124  Implement dashboard with analytics and reporting
+      ├──SPR-127  Fix critical bug in payment processing
+      ├──SPR-128  Update user profile settings
+      └──SPR-129  Implement notification system
+      """
+    When I press "backspace"
+    Then the UI should display:
+      """
+      🌱 sprout
+
+      /type to fuzzy search
+      ├──SPR-123  Add user authentication
+      ├──SPR-124  Implement dashboard with analytics and reporting
+      ├──SPR-127  Fix critical bug in payment processing
+      ├──SPR-128  Update user profile settings
+      └──SPR-129  Implement notification system
+      """

--- a/pkg/ui/features_test.go
+++ b/pkg/ui/features_test.go
@@ -209,6 +209,8 @@ func (tc *TUITestContext) iPress(key string) error {
 		keyMsg = tea.KeyMsg{Type: tea.KeyEsc}
 	case "/":
 		keyMsg = tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'/'}}
+	case "backspace":
+		keyMsg = tea.KeyMsg{Type: tea.KeyBackspace}
 	default:
 		return fmt.Errorf("unknown key: %s", key)
 	}

--- a/pkg/ui/tui.go
+++ b/pkg/ui/tui.go
@@ -530,6 +530,23 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 			return m, nil
 			
+		case tea.KeyBackspace:
+			// Handle backspace in search mode
+			if m.SearchMode && !m.Submitted && !m.SubtaskInputMode {
+				// Let the text input handle the backspace
+				m.TextInput, cmd = m.TextInput.Update(msg)
+				// Extract search query (remove the leading "/")
+				value := m.TextInput.Value()
+				if strings.HasPrefix(value, "/") {
+					m.SearchQuery = value[1:]
+				} else {
+					m.SearchQuery = value
+				}
+				// Update filtered issues
+				m.FilteredIssues = m.filterIssuesBySearch(m.SearchQuery)
+				return m, cmd
+			}
+			
 		case tea.KeyRunes:
 			// Handle "/" key to enter search mode
 			if !m.Submitted && !m.SubtaskInputMode && len(msg.Runes) == 1 && msg.Runes[0] == '/' {


### PR DESCRIPTION
## Summary
- Fixed backspace key not working in search mode - previously the character wouldn't be deleted when pressing backspace
- Added specific handling for the backspace key when in search mode
- Added BDD test to ensure backspace functionality works correctly

## Test plan
- [x] Added new BDD test scenario "Backspace works in search mode"
- [x] Test verifies that pressing backspace correctly removes characters from search query
- [x] All existing tests continue to pass

🤖 Generated with [Claude Code](https://claude.ai/code)