### PR TITLE
Fix Linear ticket ID alignment issue

### DIFF
--- a/features/navigation.feature
+++ b/features/navigation.feature
@@ -6,11 +6,11 @@ Feature: Sprout TUI Navigation
   Background:
     Given the following Linear issues exist:
       | identifier | title                                           | parent_id |
-      | SPR-123    | Add user authentication                         |           |
+      | SPR-2      | Add user authentication                         |           |
       | SPR-124    | Implement dashboard with analytics and reporting |           |
       | SPR-125    | Create analytics component                      | SPR-124   |
       | SPR-126    | Add reporting metrics                           | SPR-124   |
-      | SPR-127    | Fix critical bug in payment processing          |           |
+      | SPR-1234   | Fix critical bug in payment processing          |           |
 
   Scenario: Initial TUI display
     When I start the Sprout TUI
@@ -19,9 +19,9 @@ Feature: Sprout TUI Navigation
       🌱 sprout
 
       > sprout/█enter branch name or select suggestion below
-      ├──SPR-123  Add user authentication
-      ├──SPR-124  Implement dashboard with analytics and reporting
-      └──SPR-127  Fix critical bug in payment processing
+      ├──SPR-2     Add user authentication
+      ├──SPR-124   Implement dashboard with analytics and reporting
+      └──SPR-1234  Fix critical bug in payment processing
       """
 
   Scenario: Navigate down from input field
@@ -31,10 +31,10 @@ Feature: Sprout TUI Navigation
       """
       🌱 sprout
 
-      > sprout/spr-123-add-user-authentication
-      ├──SPR-123  Add user authentication
-      ├──SPR-124  Implement dashboard with analytics and reporting
-      └──SPR-127  Fix critical bug in payment processing
+      > sprout/spr-2-add-user-authentication
+      ├──SPR-2     Add user authentication
+      ├──SPR-124   Implement dashboard with analytics and reporting
+      └──SPR-1234  Fix critical bug in payment processing
       """
 
   Scenario: Navigate back up to input field
@@ -46,7 +46,7 @@ Feature: Sprout TUI Navigation
       🌱 sprout
 
       > sprout/█enter branch name or select suggestion below
-      ├──SPR-123  Add user authentication
-      ├──SPR-124  Implement dashboard with analytics and reporting
-      └──SPR-127  Fix critical bug in payment processing
+      ├──SPR-2     Add user authentication
+      ├──SPR-124   Implement dashboard with analytics and reporting
+      └──SPR-1234  Fix critical bug in payment processing
       """


### PR DESCRIPTION
## Summary
- Fixed alignment problem where Linear ticket IDs with different digit lengths weren't properly aligned
- Added proper padding calculation to ensure all ticket IDs align correctly in the TUI
- Updated test cases to include tickets with varying identifier lengths to catch similar issues

## Changes
- Added `MaxIdentifierWidth` field to track the longest identifier width
- Modified `buildSimpleLinearTree()` to calculate maximum identifier width
- Updated `addIssueNode()` to pad identifiers for consistent alignment
- Enhanced test data to include tickets with different digit lengths (SPR-2, SPR-124, SPR-1234)

## Before
```
TICKET-2  Foobar
TICKET-352  Flappy
TICKET-1232  Another
```

## After
```
TICKET-2     Foobar
TICKET-352   Flappy
TICKET-1232  Another
```

🤖 Generated with [Claude Code](https://claude.ai/code)