### PR TITLE
Exclude closed Linear tickets from TUI display

### DIFF
--- a/pkg/linear/client.go
+++ b/pkg/linear/client.go
@@ -184,7 +184,7 @@ func (c *Client) GetAssignedIssues() ([]Issue, error) {
 			issues(
 				filter: {
 					assignee: { isMe: { eq: true } }
-					state: { type: { neq: "completed" } }
+					state: { type: { nin: ["completed", "canceled"] } }
 				}
 				orderBy: updatedAt
 			) {
@@ -257,7 +257,11 @@ func (c *Client) GetIssueChildren(issueID string) ([]Issue, error) {
 	query := `
 		query($issueId: String!) {
 			issue(id: $issueId) {
-				children {
+				children(
+					filter: {
+						state: { type: { nin: ["completed", "canceled"] } }
+					}
+				) {
 					nodes {
 						id
 						title


### PR DESCRIPTION
## Summary
- Filter out completed and canceled Linear tickets from TUI display
- Updates both assigned issues and child issue fetching
- Users only see active tickets they can work on

## Changes
- Updated `GetAssignedIssues()` to exclude both "completed" and "canceled" state types
- Updated `GetIssueChildren()` to apply same filtering to child issues
- Changed from single `neq` filter to `nin` array filter for multiple state types

🤖 Generated with [Claude Code](https://claude.ai/code)