### PR TITLE
Add interleaved resume work queue

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,10 @@ Sprout supports configuration via `~/.sprout.json5` for customizing behavior:
   // Command to run after creating a worktree in interactive mode
   // If not specified, exits cleanly without running any command
   "defaultCommand": "code .",
+
+  // Optional command to run when resuming an existing worktree from the TUI.
+  // If omitted, Sprout reuses defaultCommand only when it does not contain $PROMPT.
+  "resumeCommand": "claude --resume",
   
   // Linear API key for issue tracking integration
   // Get your key from Linear Settings > Account > Security & Access
@@ -106,6 +110,10 @@ Sprout supports configuration via `~/.sprout.json5` for customizing behavior:
   - `"code ."` - Open in VS Code
   - `"nvim"` - Open in Neovim
   - `"bash"` - Start a new shell session
+- **`resumeCommand`**: Command to execute when opening an existing worktree from the interactive work queue. Common examples:
+  - `"claude --resume"` - Resume the previous Claude session
+  - `"code ."` - Open the existing worktree in VS Code
+  - Supports `$WORKTREE_PATH`, `$BRANCH_NAME`, and `$REPO_NAME` placeholders.
   
 - **`linearApiKey`**: Your Linear personal API key for accessing Linear tickets. Required for Linear integration features.
 - **`worktreeBasePath`**: Base directory where worktrees are created for all repositories. Supports `$REPO_BASEPATH` (parent directory of the repo), `$REPO_NAME`, and `$BRANCH_NAME`. If `$BRANCH_NAME` is included, the template is treated as the full worktree path; otherwise the branch name is appended. If not set, Sprout uses a `.worktrees` directory next to the repository.

--- a/features/cli_commands.feature
+++ b/features/cli_commands.feature
@@ -90,6 +90,7 @@ Feature: Sprout CLI Commands
       🌱 Sprout Configuration
 
         Default Command: code .
+        Resume Command: not configured
         Linear API Key: not configured
         Config Path: /Users/laurenkt/.sprout.json5
         Config File: exists
@@ -111,6 +112,7 @@ Feature: Sprout CLI Commands
       🌱 Sprout Configuration
 
         Default Command: code .
+        Resume Command: not configured
         Linear API Key: configured
         Config Path: /Users/laurenkt/.sprout.json5
         Config File: exists

--- a/features/resume_command.feature
+++ b/features/resume_command.feature
@@ -1,0 +1,42 @@
+Feature: Resume command execution
+  As a developer using Sprout
+  I want resumed worktrees to use a separate command
+  So that continuing work can run a different tool invocation from new work
+
+  Scenario: Resume uses resumeCommand when configured
+    Given a config with:
+      | key            | value           |
+      | defaultCommand | claude $PROMPT  |
+      | resumeCommand  | claude --resume |
+    And the following worktrees exist:
+      | branch         | path                           | updated_at           | merged |
+      | feature-search | /mock/worktrees/feature-search | 2026-05-01T16:00:00Z | false  |
+    When I start the Sprout TUI
+    And I press "down"
+    And I press "enter"
+    Then the post-resume command should be "cd /mock/worktrees/feature-search && claude --resume"
+
+  Scenario: Resume falls back to defaultCommand without prompt placeholder
+    Given a config with:
+      | key            | value  |
+      | defaultCommand | code . |
+    And the following worktrees exist:
+      | branch         | path                           | updated_at           | merged |
+      | feature-search | /mock/worktrees/feature-search | 2026-05-01T16:00:00Z | false  |
+    When I start the Sprout TUI
+    And I press "down"
+    And I press "enter"
+    Then the post-resume command should be "cd /mock/worktrees/feature-search && code ."
+
+  Scenario: Resume does not fall back to prompt-based defaultCommand
+    Given a config with:
+      | key            | value          |
+      | defaultCommand | claude $PROMPT |
+    And the following worktrees exist:
+      | branch         | path                           | updated_at           | merged |
+      | feature-search | /mock/worktrees/feature-search | 2026-05-01T16:00:00Z | false  |
+    When I start the Sprout TUI
+    And I press "down"
+    And I press "enter"
+    Then no post-resume command should run
+    And the TUI should resume worktree "/mock/worktrees/feature-search"

--- a/features/resume_work_queue.feature
+++ b/features/resume_work_queue.feature
@@ -1,0 +1,139 @@
+Feature: Resume work from an interleaved work queue
+  As a developer using Sprout
+  I want Linear tickets and existing worktrees shown together
+  So that I can either start new work or resume existing work quickly
+
+  Background:
+    Given the following Linear issues exist:
+      | identifier | title                 | parent_id | status      | updated_at           |
+      | SPR-124    | Dashboard analytics   |           | In Progress | 2026-05-01T10:00:00Z |
+      | SPR-125    | Create analytics card | SPR-124   | Todo        | 2026-05-01T09:00:00Z |
+      | SPR-140    | Fix onboarding copy   |           | Todo        | 2026-04-30T12:00:00Z |
+      | SPR-141    | Old auth cleanup      |           | Done        | 2026-05-02T09:00:00Z |
+    And the following worktrees exist:
+      | branch                      | path                                         | updated_at           | merged |
+      | spr-124-dashboard-analytics | /mock/worktrees/spr-124-dashboard-analytics | 2026-05-02T08:00:00Z | false  |
+      | feature-search              | /mock/worktrees/feature-search              | 2026-05-01T16:00:00Z | false  |
+      | misc-cleanup                | /mock/worktrees/misc-cleanup                | 2026-04-29T10:00:00Z | false  |
+      | old-merged-branch           | /mock/worktrees/old-merged-branch           | 2026-05-02T07:00:00Z | true   |
+
+  Scenario: Initial list interleaves active tickets and worktrees
+    When I start the Sprout TUI
+    Then the UI should display:
+      """
+      🌱 sprout
+
+      > sprout/█enter branch name or select suggestion below
+      ├──feature-search
+      ├──SPR-124   In Progress  Dashboard analytics
+      ├──SPR-140   Todo         Fix onboarding copy
+      └──misc-cleanup
+      [worktree <tab>] [a all] [u unassign] [d done] [z undo]
+      """
+
+  Scenario: Matching worktree and Linear ticket render as a single Linear row
+    When I start the Sprout TUI
+    Then the UI should not display "spr-124-dashboard-analytics"
+    And the UI should display "SPR-124   In Progress  Dashboard analytics"
+
+  Scenario: Selecting a matched Linear row resumes its existing worktree
+    Given I start the Sprout TUI
+    When I press "down"
+    And I press "down"
+    And I press "enter"
+    Then the TUI should resume worktree "/mock/worktrees/spr-124-dashboard-analytics"
+    And no new worktree should be created
+
+  Scenario: Selecting a Linear-only row creates a new worktree
+    Given I start the Sprout TUI
+    When I press "down"
+    And I press "down"
+    And I press "down"
+    And I press "enter"
+    Then a worktree should be created for branch "spr-140-fix-onboarding-copy"
+
+  Scenario: Selecting a worktree-only row resumes that worktree
+    Given I start the Sprout TUI
+    When I press "down"
+    And I press "enter"
+    Then the TUI should resume worktree "/mock/worktrees/feature-search"
+    And no new worktree should be created
+
+  Scenario: Identifier matching is delimiter safe
+    Given the following Linear issues exist:
+      | identifier | title       | parent_id | status | updated_at           |
+      | SPR-12     | Short issue |           | Todo   | 2026-05-01T10:00:00Z |
+    And the following worktrees exist:
+      | branch        | path                    | updated_at           | merged |
+      | spr-123-other | /mock/worktrees/spr-123 | 2026-05-02T08:00:00Z | false  |
+    When I start the Sprout TUI
+    Then the UI should display "SPR-12"
+    And the UI should display "spr-123-other"
+
+  Scenario: Disclosures still expand Linear sub-tickets
+    Given I start the Sprout TUI
+    When I press "down"
+    And I press "down"
+    And I press "right"
+    Then the UI should display:
+      """
+      🌱 sprout
+
+      > sprout/spr-124-dashboard-analytics
+      ├──feature-search
+      ├──SPR-124   In Progress  Dashboard analytics
+      │  ├──SPR-125   Todo         Create analytics card
+      │  └──+ Add subtask
+      ├──SPR-140   Todo         Fix onboarding copy
+      └──misc-cleanup
+      [worktree <tab>] [a all] [u unassign] [d done] [z undo]
+      """
+
+  Scenario: Worktree-only rows are leaves
+    Given I start the Sprout TUI
+    When I press "down"
+    And I press "right"
+    Then the UI should display:
+      """
+      🌱 sprout
+
+      > sprout/feature-search
+      ├──feature-search
+      ├──SPR-124   In Progress  Dashboard analytics
+      ├──SPR-140   Todo         Fix onboarding copy
+      └──misc-cleanup
+      [worktree <tab>] [a all] [u unassign] [d done] [z undo]
+      """
+
+  Scenario: Closed and merged rows are hidden by default
+    When I start the Sprout TUI
+    Then the UI should not display "SPR-141"
+    And the UI should not display "old-merged-branch"
+
+  Scenario: Toggle all rows shows closed and merged items after active items
+    Given I start the Sprout TUI
+    When I press "a"
+    Then the UI should display:
+      """
+      🌱 sprout
+
+      > sprout/█enter branch name or select suggestion below
+      ├──feature-search
+      ├──SPR-124   In Progress  Dashboard analytics
+      ├──SPR-140   Todo         Fix onboarding copy
+      ├──misc-cleanup
+      ├──SPR-141   Done         Old auth cleanup
+      └──old-merged-branch
+      [worktree <tab>] [a active] [u unassign] [d done] [z undo]
+      """
+
+  Scenario: Default list is limited to twenty active rows
+    Given 25 active work queue rows exist
+    When I start the Sprout TUI
+    Then the UI should show 20 work queue rows
+
+  Scenario: Search filters tickets and branch names
+    Given I start the Sprout TUI
+    When I type "/search"
+    Then the UI should display "feature-search"
+    And the UI should not display "SPR-124"

--- a/pkg/cli/commands.go
+++ b/pkg/cli/commands.go
@@ -162,6 +162,12 @@ func HandleDoctorCommand(deps *Dependencies) error {
 	}
 	fmt.Fprintf(deps.Output, "  %s: %s\n", accentStyle.Render("Default Command"), normalStyle.Render(defaultCmd))
 
+	resumeCmd := cfg.ResumeCommand
+	if resumeCmd == "" {
+		resumeCmd = "not configured"
+	}
+	fmt.Fprintf(deps.Output, "  %s: %s\n", accentStyle.Render("Resume Command"), normalStyle.Render(resumeCmd))
+
 	if cfg.GetLinearAPIKey() != "" {
 		fmt.Fprintf(deps.Output, "  %s: %s\n", accentStyle.Render("Linear API Key"), normalStyle.Render("configured"))
 	} else {
@@ -277,7 +283,7 @@ func Run(args []string) int {
 		fmt.Printf("Error: Failed to initialize dependencies: %v\n", err)
 		return 1
 	}
-	
+
 	return RunWithDependencies(args, deps)
 }
 
@@ -347,23 +353,23 @@ func handleCreateCommandWithDeps(args []string, deps *Dependencies) error {
 	if len(args) == 0 {
 		return fmt.Errorf("branch name is required. Usage: sprout create <branch-name> [command...]")
 	}
-	
+
 	branchName := args[0]
-	
+
 	worktreePath, err := deps.WorktreeManager.CreateWorktree(branchName)
 	if err != nil {
 		return err
 	}
-	
+
 	fmt.Fprintf(deps.ErrorOutput, "Worktree ready at: %s\n", worktreePath)
-	
+
 	// If no command provided, check for default command
 	if len(args) == 1 {
 		cfg, err := deps.ConfigLoader.GetConfig()
 		if err != nil {
 			return fmt.Errorf("failed to load config: %w", err)
 		}
-		
+
 		defaultCmd := cfg.GetDefaultCommand()
 		if len(defaultCmd) > 0 {
 			// Execute the default command in the worktree directory
@@ -372,7 +378,7 @@ func handleCreateCommandWithDeps(args []string, deps *Dependencies) error {
 			cmd.Stdin = os.Stdin
 			cmd.Stdout = deps.Output
 			cmd.Stderr = deps.ErrorOutput
-			
+
 			if err := cmd.Run(); err != nil {
 				if exitError, ok := err.(*exec.ExitError); ok {
 					if status, ok := exitError.Sys().(syscall.WaitStatus); ok {
@@ -385,22 +391,22 @@ func handleCreateCommandWithDeps(args []string, deps *Dependencies) error {
 			fmt.Fprintf(deps.ErrorOutput, "\nWorktree directory: %s\n", worktreePath)
 			return nil
 		}
-		
+
 		// No default command, output path for shell evaluation
 		fmt.Fprint(deps.Output, worktreePath)
 		return nil
 	}
-	
+
 	// Execute the provided command in the worktree directory
 	command := args[1]
 	commandArgs := args[2:]
-	
+
 	cmd := exec.Command(command, commandArgs...)
 	cmd.Dir = worktreePath
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = deps.Output
 	cmd.Stderr = deps.ErrorOutput
-	
+
 	if err := cmd.Run(); err != nil {
 		if exitError, ok := err.(*exec.ExitError); ok {
 			if status, ok := exitError.Sys().(syscall.WaitStatus); ok {
@@ -410,7 +416,7 @@ func handleCreateCommandWithDeps(args []string, deps *Dependencies) error {
 		}
 		return fmt.Errorf("command failed: %w", err)
 	}
-	
+
 	fmt.Fprintf(deps.ErrorOutput, "\nWorktree directory: %s\n", worktreePath)
 	return nil
 }
@@ -420,7 +426,7 @@ func handlePruneCommandWithDeps(args []string, deps *Dependencies) error {
 		// Prune all merged branches
 		return deps.WorktreeManager.PruneAllMerged()
 	}
-	
+
 	branchName := args[0]
 	return deps.WorktreeManager.PruneWorktree(branchName)
 }

--- a/pkg/cli/mocks.go
+++ b/pkg/cli/mocks.go
@@ -24,6 +24,10 @@ func (m *MockWorktreeManager) ListWorktrees() ([]git.Worktree, error) {
 	return m.Worktrees, nil
 }
 
+func (m *MockWorktreeManager) ListWorktreesForTUI() ([]git.Worktree, error) {
+	return m.Worktrees, nil
+}
+
 func (m *MockWorktreeManager) PruneWorktree(branchName string) error {
 	return nil
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -15,6 +15,7 @@ const PromptPlaceholder = "$PROMPT"
 
 type Config struct {
 	DefaultCommand    string              `json:"defaultCommand,omitempty"`
+	ResumeCommand     string              `json:"resumeCommand,omitempty"`
 	LinearAPIKey      string              `json:"linearApiKey,omitempty"`
 	SparseCheckout    map[string][]string `json:"sparseCheckout,omitempty"`
 	WorktreeBasePath  string              `json:"worktreeBasePath,omitempty"`
@@ -45,6 +46,7 @@ func (fl *FileLoader) GetConfig() (*Config, error) {
 func DefaultConfig() *Config {
 	return &Config{
 		DefaultCommand:    "",
+		ResumeCommand:     "",
 		LinearAPIKey:      "",
 		SparseCheckout:    make(map[string][]string),
 		WorktreeBasePath:  "",
@@ -83,6 +85,7 @@ func Load() (*Config, error) {
 	// Check for unknown keys
 	validKeys := map[string]bool{
 		"defaultCommand":    true,
+		"resumeCommand":     true,
 		"linearApiKey":      true,
 		"sparseCheckout":    true,
 		"worktreeBasePath":  true,
@@ -97,7 +100,7 @@ func Load() (*Config, error) {
 	}
 
 	if len(unknownKeys) > 0 {
-		return nil, fmt.Errorf("unknown config keys found: %v\n\nValid config keys are:\n  - defaultCommand: string (command to run by default in new worktrees)\n  - linearApiKey: string (API key for Linear integration)\n  - sparseCheckout: object (map of repository paths to directory arrays)\n  - worktreeBasePath: string (base worktree directory with optional variables)\n  - worktreeBasePaths: object (deprecated: map of repository names or paths to base worktree directories)", unknownKeys)
+		return nil, fmt.Errorf("unknown config keys found: %v\n\nValid config keys are:\n  - defaultCommand: string (command to run by default in new worktrees)\n  - resumeCommand: string (command to run when resuming existing worktrees)\n  - linearApiKey: string (API key for Linear integration)\n  - sparseCheckout: object (map of repository paths to directory arrays)\n  - worktreeBasePath: string (base worktree directory with optional variables)\n  - worktreeBasePaths: object (deprecated: map of repository names or paths to base worktree directories)", unknownKeys)
 	}
 
 	// Now parse into the actual config struct
@@ -140,15 +143,21 @@ func getConfigPath() (string, error) {
 }
 
 func (c *Config) GetDefaultCommand() []string {
-	if c.DefaultCommand == "" {
+	return parseConfiguredCommand(c.DefaultCommand)
+}
+
+func (c *Config) GetResumeCommand() []string {
+	return parseConfiguredCommand(c.ResumeCommand)
+}
+
+func parseConfiguredCommand(command string) []string {
+	if strings.TrimSpace(command) == "" {
 		return nil
 	}
-
-	parts := parseCommandLine(c.DefaultCommand)
+	parts := parseCommandLine(command)
 	if len(parts) == 0 {
 		return nil
 	}
-
 	return parts
 }
 
@@ -173,6 +182,31 @@ func ResolveDefaultCommand(defaultCmdArgs []string, prompt string) []string {
 		resolved[i] = strings.ReplaceAll(arg, PromptPlaceholder, prompt)
 	}
 
+	return resolved
+}
+
+type ResumeContext struct {
+	WorktreePath string
+	BranchName   string
+	RepoName     string
+}
+
+func ResolveResumeCommand(resumeCmdArgs, defaultCmdArgs []string, ctx ResumeContext) []string {
+	args := resumeCmdArgs
+	if len(args) == 0 && !NeedsPromptCapture(defaultCmdArgs) {
+		args = defaultCmdArgs
+	}
+	if len(args) == 0 {
+		return nil
+	}
+
+	resolved := make([]string, len(args))
+	for i, arg := range args {
+		arg = strings.ReplaceAll(arg, "$WORKTREE_PATH", ctx.WorktreePath)
+		arg = strings.ReplaceAll(arg, "$BRANCH_NAME", ctx.BranchName)
+		arg = strings.ReplaceAll(arg, "$REPO_NAME", ctx.RepoName)
+		resolved[i] = arg
+	}
 	return resolved
 }
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -77,6 +77,20 @@ func TestGetDefaultCommand(t *testing.T) {
 	}
 }
 
+func TestGetResumeCommand(t *testing.T) {
+	cfg := &Config{ResumeCommand: "claude --resume"}
+	result := cfg.GetResumeCommand()
+	expected := []string{"claude", "--resume"}
+	if len(result) != len(expected) {
+		t.Fatalf("GetResumeCommand() returned %d args, expected %d", len(result), len(expected))
+	}
+	for i := range expected {
+		if result[i] != expected[i] {
+			t.Fatalf("GetResumeCommand() arg[%d] = %q, want %q", i, result[i], expected[i])
+		}
+	}
+}
+
 func TestNeedsPromptCapture(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -163,6 +177,60 @@ func TestResolveDefaultCommand(t *testing.T) {
 			for i := range result {
 				if result[i] != tt.expected[i] {
 					t.Fatalf("ResolveDefaultCommand() arg[%d] = %q, want %q", i, result[i], tt.expected[i])
+				}
+			}
+		})
+	}
+}
+
+func TestResolveResumeCommand(t *testing.T) {
+	ctx := ResumeContext{
+		WorktreePath: "/tmp/worktrees/feature",
+		BranchName:   "feature",
+		RepoName:     "sprout",
+	}
+
+	tests := []struct {
+		name        string
+		resumeArgs  []string
+		defaultArgs []string
+		expected    []string
+	}{
+		{
+			name:        "uses resume command",
+			resumeArgs:  []string{"claude", "--resume"},
+			defaultArgs: []string{"claude", "$PROMPT"},
+			expected:    []string{"claude", "--resume"},
+		},
+		{
+			name:        "falls back to non prompt default",
+			resumeArgs:  nil,
+			defaultArgs: []string{"code", "."},
+			expected:    []string{"code", "."},
+		},
+		{
+			name:        "does not fall back to prompt default",
+			resumeArgs:  nil,
+			defaultArgs: []string{"claude", "$PROMPT"},
+			expected:    nil,
+		},
+		{
+			name:        "substitutes resume placeholders",
+			resumeArgs:  []string{"tool", "$WORKTREE_PATH", "$BRANCH_NAME", "$REPO_NAME"},
+			defaultArgs: nil,
+			expected:    []string{"tool", "/tmp/worktrees/feature", "feature", "sprout"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := ResolveResumeCommand(tt.resumeArgs, tt.defaultArgs, ctx)
+			if len(result) != len(tt.expected) {
+				t.Fatalf("ResolveResumeCommand() returned %d args, expected %d: %v", len(result), len(tt.expected), result)
+			}
+			for i := range tt.expected {
+				if result[i] != tt.expected[i] {
+					t.Fatalf("ResolveResumeCommand() arg[%d] = %q, want %q", i, result[i], tt.expected[i])
 				}
 			}
 		})

--- a/pkg/git/mock.go
+++ b/pkg/git/mock.go
@@ -73,6 +73,10 @@ func (m *MockWorktreeManager) ListWorktrees() ([]Worktree, error) {
 	return m.worktrees, nil
 }
 
+func (m *MockWorktreeManager) ListWorktreesForTUI() ([]Worktree, error) {
+	return m.worktrees, nil
+}
+
 // PruneWorktree removes a worktree from the mock list by branch name
 func (m *MockWorktreeManager) PruneWorktree(branchName string) error {
 	for i, wt := range m.worktrees {

--- a/pkg/git/worktree.go
+++ b/pkg/git/worktree.go
@@ -6,6 +6,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"sprout/pkg/config"
 	"sprout/pkg/github"
@@ -16,6 +17,7 @@ type WorktreeManagerInterface interface {
 	CreateWorktree(branchName string) (string, error)
 	CreateBranch(branchName string) error
 	ListWorktrees() ([]Worktree, error)
+	ListWorktreesForTUI() ([]Worktree, error)
 	PruneWorktree(branchName string) error
 	PruneAllMerged() error
 }
@@ -263,10 +265,13 @@ func extractRepoNameFromURL(url string) string {
 }
 
 type Worktree struct {
-	Path     string
-	Branch   string
-	Commit   string
-	PRStatus string
+	Path      string
+	Branch    string
+	Commit    string
+	PRStatus  string
+	UpdatedAt time.Time
+	Merged    bool
+	Prunable  bool
 }
 
 func (wm *WorktreeManager) ListWorktrees() ([]Worktree, error) {
@@ -282,6 +287,37 @@ func (wm *WorktreeManager) ListWorktrees() ([]Worktree, error) {
 
 	for i := range worktrees {
 		worktrees[i].PRStatus = wm.githubClient.GetPRStatus(worktrees[i].Branch)
+	}
+
+	return worktrees, nil
+}
+
+func (wm *WorktreeManager) ListWorktreesForTUI() ([]Worktree, error) {
+	cmd := exec.Command("git", "worktree", "list", "--porcelain")
+	cmd.Dir = wm.repoRoot
+
+	output, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("failed to list worktrees: %w", err)
+	}
+
+	worktrees := parseWorktreeList(string(output))
+	commitTimes := wm.branchCommitTimes()
+	mergedBranches := wm.mergedBranches()
+
+	for i := range worktrees {
+		if updatedAt, ok := commitTimes[worktrees[i].Branch]; ok {
+			worktrees[i].UpdatedAt = updatedAt
+		}
+		if info, err := os.Stat(worktrees[i].Path); err == nil {
+			if info.ModTime().After(worktrees[i].UpdatedAt) {
+				worktrees[i].UpdatedAt = info.ModTime()
+			}
+		}
+		worktrees[i].Merged = mergedBranches[worktrees[i].Branch]
+		if worktrees[i].Merged {
+			worktrees[i].PRStatus = "Merged"
+		}
 	}
 
 	return worktrees, nil
@@ -316,6 +352,8 @@ func parseWorktreeList(output string) []Worktree {
 			}
 		case "HEAD":
 			current.Commit = value
+		case "prunable":
+			current.Prunable = true
 		}
 	}
 
@@ -324,6 +362,126 @@ func parseWorktreeList(output string) []Worktree {
 	}
 
 	return worktrees
+}
+
+func (wm *WorktreeManager) branchCommitTimes() map[string]time.Time {
+	result := make(map[string]time.Time)
+	cmd := exec.Command("git", "for-each-ref", "refs/heads", "--format=%(refname:short)%00%(committerdate:iso-strict)")
+	cmd.Dir = wm.repoRoot
+	output, err := cmd.Output()
+	if err != nil {
+		return result
+	}
+	for _, line := range strings.Split(strings.TrimSpace(string(output)), "\n") {
+		if line == "" {
+			continue
+		}
+		parts := strings.SplitN(line, "\x00", 2)
+		if len(parts) != 2 {
+			continue
+		}
+		if ts, err := time.Parse(time.RFC3339, parts[1]); err == nil {
+			result[parts[0]] = ts
+		}
+	}
+	return result
+}
+
+func (wm *WorktreeManager) mergedBranches() map[string]bool {
+	result := make(map[string]bool)
+	baseBranch := wm.getCachedBaseBranch()
+	if baseBranch == "" {
+		return result
+	}
+	remoteBranches := wm.remoteBranches()
+	pushedBranches := wm.pushedBranchEvidence()
+	cmd := exec.Command("git", "branch", "--merged", baseBranch, "--format=%(refname:short)")
+	cmd.Dir = wm.repoRoot
+	output, err := cmd.Output()
+	if err != nil {
+		return result
+	}
+	for _, line := range strings.Split(string(output), "\n") {
+		branch := strings.TrimSpace(strings.TrimPrefix(line, "*"))
+		if branch != "" && (remoteBranches[branch] || pushedBranches[branch]) {
+			result[branch] = true
+		}
+	}
+	return result
+}
+
+func (wm *WorktreeManager) remoteBranches() map[string]bool {
+	result := make(map[string]bool)
+	cmd := exec.Command("git", "for-each-ref", "refs/remotes/origin", "--format=%(refname:short)")
+	cmd.Dir = wm.repoRoot
+	output, err := cmd.Output()
+	if err != nil {
+		return result
+	}
+	for _, line := range strings.Split(string(output), "\n") {
+		remoteBranch := strings.TrimSpace(line)
+		if strings.HasPrefix(remoteBranch, "origin/") {
+			branch := strings.TrimPrefix(remoteBranch, "origin/")
+			if branch != "HEAD" && branch != "" {
+				result[branch] = true
+			}
+		}
+	}
+	return result
+}
+
+func (wm *WorktreeManager) pushedBranchEvidence() map[string]bool {
+	result := make(map[string]bool)
+	cmd := exec.Command("git", "reflog", "--all", "--oneline")
+	cmd.Dir = wm.repoRoot
+	output, err := cmd.Output()
+	if err != nil {
+		return result
+	}
+	for _, line := range strings.Split(string(output), "\n") {
+		for _, field := range strings.Fields(line) {
+			if strings.HasPrefix(field, "origin/") {
+				branch := strings.Trim(strings.TrimPrefix(field, "origin/"), ":,;)")
+				if branch != "" && branch != "HEAD" {
+					result[branch] = true
+				}
+			}
+		}
+	}
+	return result
+}
+
+func (wm *WorktreeManager) getCachedBaseBranch() string {
+	cmd := exec.Command("git", "symbolic-ref", "refs/remotes/origin/HEAD")
+	cmd.Dir = wm.repoRoot
+	if output, err := cmd.Output(); err == nil {
+		ref := strings.TrimSpace(string(output))
+		const prefix = "refs/remotes/origin/"
+		if strings.HasPrefix(ref, prefix) {
+			branch := strings.TrimPrefix(ref, prefix)
+			if wm.branchExists("refs/remotes/origin/" + branch) {
+				return "origin/" + branch
+			}
+			if wm.branchExists("refs/heads/" + branch) {
+				return branch
+			}
+		}
+	}
+
+	for _, ref := range []struct {
+		verify string
+		name   string
+	}{
+		{"refs/heads/main", "main"},
+		{"refs/heads/master", "master"},
+		{"refs/remotes/origin/main", "origin/main"},
+		{"refs/remotes/origin/master", "origin/master"},
+	} {
+		if wm.branchExists(ref.verify) {
+			return ref.name
+		}
+	}
+	return ""
 }
 
 func (wm *WorktreeManager) getBaseBranch() (string, error) {

--- a/pkg/git/worktree_test.go
+++ b/pkg/git/worktree_test.go
@@ -278,6 +278,76 @@ func TestCreateWorktreeFromBase(t *testing.T) {
 	}
 }
 
+func TestListWorktreesForTUIDoesNotMarkFreshWorktreeAsMerged(t *testing.T) {
+	tempDir, err := os.MkdirTemp("", "sprout-fresh-worktree-*")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer func() {
+		os.RemoveAll(tempDir)
+		os.RemoveAll(filepath.Join(filepath.Dir(tempDir), "fresh-worktree"))
+	}()
+
+	cmd := exec.Command("git", "init")
+	cmd.Dir = tempDir
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("Failed to init git repo: %v", err)
+	}
+
+	cmd = exec.Command("git", "config", "user.email", "test@example.com")
+	cmd.Dir = tempDir
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("Failed to configure git email: %v", err)
+	}
+
+	cmd = exec.Command("git", "config", "user.name", "Test User")
+	cmd.Dir = tempDir
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("Failed to configure git name: %v", err)
+	}
+
+	testFile := filepath.Join(tempDir, "README.md")
+	if err := os.WriteFile(testFile, []byte("# Test"), 0644); err != nil {
+		t.Fatalf("Failed to create test file: %v", err)
+	}
+
+	cmd = exec.Command("git", "add", ".")
+	cmd.Dir = tempDir
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("Failed to add files: %v", err)
+	}
+
+	cmd = exec.Command("git", "commit", "-m", "Initial commit")
+	cmd.Dir = tempDir
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("Failed to commit: %v", err)
+	}
+
+	worktreePath := filepath.Join(filepath.Dir(tempDir), "fresh-worktree")
+	cmd = exec.Command("git", "worktree", "add", worktreePath, "-b", "fresh-worktree", "master")
+	cmd.Dir = tempDir
+	if output, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("Failed to create fresh worktree: %v\nOutput: %s", err, string(output))
+	}
+
+	wm := &WorktreeManager{repoRoot: tempDir}
+	worktrees, err := wm.ListWorktreesForTUI()
+	if err != nil {
+		t.Fatalf("ListWorktreesForTUI returned error: %v", err)
+	}
+
+	for _, wt := range worktrees {
+		if wt.Branch == "fresh-worktree" {
+			if wt.Merged {
+				t.Fatalf("fresh worktree branch should not be treated as merged")
+			}
+			return
+		}
+	}
+
+	t.Fatalf("fresh worktree was not returned in TUI worktrees: %#v", worktrees)
+}
+
 func TestCreateBranch(t *testing.T) {
 	tempDir, err := os.MkdirTemp("", "sprout-branch-*")
 	if err != nil {

--- a/pkg/linear/client.go
+++ b/pkg/linear/client.go
@@ -187,7 +187,6 @@ func (c *Client) GetAssignedIssues() ([]Issue, error) {
 			issues(
 				filter: {
 					assignee: { isMe: { eq: true } }
-					state: { type: { nin: ["completed", "canceled"] } }
 				}
 				orderBy: updatedAt
 			) {
@@ -295,9 +294,6 @@ func (c *Client) GetIssueChildren(issueID string) ([]Issue, error) {
 		query($issueId: String!) {
 			issue(id: $issueId) {
 				children(
-					filter: {
-						state: { type: { nin: ["completed", "canceled"] } }
-					}
 				) {
 					nodes {
 						id

--- a/pkg/ui/features_test.go
+++ b/pkg/ui/features_test.go
@@ -25,8 +25,11 @@ type TUITestContext struct {
 	fakeClient          *linear.FakeLinearClient
 	fakeWorktreeManager *testWorktreeManager
 	defaultWorktreeCmd  string
+	resumeWorktreeCmd   string
 	postCreateRuns      []string
+	postResumeRuns      []string
 	postCreateRan       bool
+	postResumeRan       bool
 	pendingMsgs         chan tea.Msg
 	t                   *testing.T
 	terminalWidth       int
@@ -39,8 +42,11 @@ func NewTUITestContext(t *testing.T) *TUITestContext {
 		fakeClient:          linear.NewFakeLinearClient(),
 		fakeWorktreeManager: &testWorktreeManager{},
 		defaultWorktreeCmd:  "",
+		resumeWorktreeCmd:   "",
 		postCreateRuns:      nil,
+		postResumeRuns:      nil,
 		postCreateRan:       false,
+		postResumeRan:       false,
 		pendingMsgs:         make(chan tea.Msg, 64),
 		t:                   t,
 		terminalWidth:       80, // Default width
@@ -53,6 +59,7 @@ type testWorktreeManager struct {
 	lastCreatedWorktree string
 	lastCreatedBranch   string
 	gitCommands         []string
+	worktrees           []git.Worktree
 	delayCreate         bool
 	createUnblock       chan struct{}
 }
@@ -84,7 +91,11 @@ func (m *testWorktreeManager) CreateBranch(branchName string) error {
 }
 
 func (m *testWorktreeManager) ListWorktrees() ([]git.Worktree, error) {
-	return nil, nil
+	return m.worktrees, nil
+}
+
+func (m *testWorktreeManager) ListWorktreesForTUI() ([]git.Worktree, error) {
+	return m.worktrees, nil
 }
 
 func (m *testWorktreeManager) PruneWorktree(branchName string) error {
@@ -197,10 +208,14 @@ func (tc *TUITestContext) theFollowingLinearIssuesExist(issueTable *godog.Table)
 		// Default status if not provided in table
 		var status linear.State
 		if len(row.Cells) > 3 && row.Cells[3].Value != "" {
+			stateType := strings.ToLower(strings.ReplaceAll(row.Cells[3].Value, " ", "_"))
+			if stateType == "done" {
+				stateType = "completed"
+			}
 			status = linear.State{
 				ID:   identifier + "-state",
 				Name: row.Cells[3].Value,
-				Type: strings.ToLower(strings.ReplaceAll(row.Cells[3].Value, " ", "_")),
+				Type: stateType,
 			}
 		} else {
 			// Default status for tests
@@ -209,6 +224,11 @@ func (tc *TUITestContext) theFollowingLinearIssuesExist(issueTable *godog.Table)
 				Name: "Todo",
 				Type: "todo",
 			}
+		}
+
+		var updatedAt time.Time
+		if len(row.Cells) > 4 && row.Cells[4].Value != "" {
+			updatedAt, _ = time.Parse(time.RFC3339, strings.TrimSpace(row.Cells[4].Value))
 		}
 
 		// Create issue with identifier as ID for simplicity in tests
@@ -221,12 +241,42 @@ func (tc *TUITestContext) theFollowingLinearIssuesExist(issueTable *godog.Table)
 			Expanded:    false,
 			Depth:       0,                // Will be set by UI based on hierarchy
 			Children:    []linear.Issue{}, // Not used in fake client
+			UpdatedAt:   updatedAt,
 		}
 
 		// Add to fake client (it handles parent-child relationships)
 		tc.fakeClient.AddIssue(issue, parentID)
 	}
 
+	return nil
+}
+
+func (tc *TUITestContext) theFollowingWorktreesExist(worktreeTable *godog.Table) error {
+	var worktrees []git.Worktree
+	for i, row := range worktreeTable.Rows {
+		if i == 0 {
+			continue
+		}
+		branch := strings.TrimSpace(row.Cells[0].Value)
+		path := strings.TrimSpace(row.Cells[1].Value)
+		updatedAt, _ := time.Parse(time.RFC3339, strings.TrimSpace(row.Cells[2].Value))
+		merged := false
+		if len(row.Cells) > 3 {
+			merged = strings.EqualFold(strings.TrimSpace(row.Cells[3].Value), "true")
+		}
+		prStatus := ""
+		if merged {
+			prStatus = "Merged"
+		}
+		worktrees = append(worktrees, git.Worktree{
+			Branch:    branch,
+			Path:      path,
+			UpdatedAt: updatedAt,
+			Merged:    merged,
+			PRStatus:  prStatus,
+		})
+	}
+	tc.fakeWorktreeManager.worktrees = worktrees
 	return nil
 }
 
@@ -238,6 +288,7 @@ func (tc *TUITestContext) iStartTheSproutTUI() error {
 	var err error
 	tc.model, err = NewTUIWithDependenciesAndConfig(tc.fakeWorktreeManager, tc.fakeClient, &config.Config{
 		DefaultCommand: tc.defaultWorktreeCmd,
+		ResumeCommand:  tc.resumeWorktreeCmd,
 	})
 	if err != nil {
 		return err
@@ -273,6 +324,17 @@ func (tc *TUITestContext) executeInitialization() {
 		}
 
 		// Update the model with the loading result
+		updatedModel, _ := tc.model.Update(msg)
+		tc.model = updatedModel.(model)
+	}
+	if tc.model.WorktreeManager != nil && tc.model.WorktreesLoading {
+		worktrees, err := tc.model.WorktreeManager.ListWorktreesForTUI()
+		var msg tea.Msg
+		if err != nil {
+			msg = worktreesErrorMsg{err}
+		} else {
+			msg = worktreesLoadedMsg{worktrees}
+		}
 		updatedModel, _ := tc.model.Update(msg)
 		tc.model = updatedModel.(model)
 	}
@@ -315,6 +377,8 @@ func (tc *TUITestContext) iPress(key string) error {
 		keyMsg = tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'d'}}
 	case "z":
 		keyMsg = tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'z'}}
+	case "a":
+		keyMsg = tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'a'}}
 	default:
 		return fmt.Errorf("unknown key: %s", key)
 	}
@@ -421,6 +485,7 @@ func (tc *TUITestContext) processMsg(msg tea.Msg) {
 	updatedModel, _ := tc.model.Update(msg)
 	tc.model = updatedModel.(model)
 	tc.maybeRunPostCreateCommand()
+	tc.maybeRunPostResumeCommand()
 }
 
 func (tc *TUITestContext) maybeRunPostCreateCommand() {
@@ -444,10 +509,35 @@ func (tc *TUITestContext) maybeRunPostCreateCommand() {
 	tc.postCreateRan = true
 }
 
+func (tc *TUITestContext) maybeRunPostResumeCommand() {
+	if tc.postResumeRan {
+		return
+	}
+	if !tc.model.Done || !tc.model.Success || !tc.model.Resumed || tc.model.WorktreePath == "" {
+		return
+	}
+
+	cfg := &config.Config{
+		DefaultCommand: tc.defaultWorktreeCmd,
+		ResumeCommand:  tc.resumeWorktreeCmd,
+	}
+	resolved := config.ResolveResumeCommand(cfg.GetResumeCommand(), cfg.GetDefaultCommand(), config.ResumeContext{
+		WorktreePath: tc.model.WorktreePath,
+		BranchName:   tc.model.ResumeBranch,
+		RepoName:     "sprout",
+	})
+	if len(resolved) > 0 {
+		tc.postResumeRuns = append(tc.postResumeRuns, fmt.Sprintf("cd %s && %s", tc.model.WorktreePath, formatCommandArgs(resolved)))
+	}
+	tc.postResumeRan = true
+}
+
 func formatCommandArgs(args []string) string {
 	parts := make([]string, len(args))
 	for i, arg := range args {
-		if arg == "" || strings.ContainsAny(arg, " \t\n\"'") {
+		if strings.Contains(arg, "\n") {
+			parts[i] = `"` + arg + `"`
+		} else if arg == "" || strings.ContainsAny(arg, " \t\"'") {
 			parts[i] = strconv.Quote(arg)
 		} else {
 			parts[i] = arg
@@ -658,9 +748,10 @@ func (tc *TUITestContext) parseExpectedCommands(commandsTable *godog.Table) ([]s
 }
 
 func (tc *TUITestContext) allRecordedCommands() []string {
-	commands := make([]string, 0, len(tc.fakeWorktreeManager.gitCommands)+len(tc.postCreateRuns))
+	commands := make([]string, 0, len(tc.fakeWorktreeManager.gitCommands)+len(tc.postCreateRuns)+len(tc.postResumeRuns))
 	commands = append(commands, tc.fakeWorktreeManager.gitCommands...)
 	commands = append(commands, tc.postCreateRuns...)
+	commands = append(commands, tc.postResumeRuns...)
 	return commands
 }
 
@@ -690,7 +781,113 @@ func (tc *TUITestContext) theFollowingCommandsShouldBeRun(commandsTable *godog.T
 }
 
 func (tc *TUITestContext) theDefaultWorktreeCommandIs(command string) error {
-	tc.defaultWorktreeCmd = strings.TrimSpace(command)
+	tc.defaultWorktreeCmd = strings.ReplaceAll(strings.TrimSpace(command), `\`, "")
+	return nil
+}
+
+func (tc *TUITestContext) aConfigWith(configTable *godog.Table) error {
+	for i, row := range configTable.Rows {
+		if i == 0 {
+			continue
+		}
+		key := strings.TrimSpace(row.Cells[0].Value)
+		value := strings.TrimSpace(row.Cells[1].Value)
+		switch key {
+		case "defaultCommand", "default_command":
+			tc.defaultWorktreeCmd = value
+		case "resumeCommand", "resume_command":
+			tc.resumeWorktreeCmd = value
+		}
+	}
+	return nil
+}
+
+func (tc *TUITestContext) theTUIShouldResumeWorktree(path string) error {
+	tc.drainWithTimeout(20 * time.Millisecond)
+	if !tc.model.Resumed {
+		return fmt.Errorf("expected TUI to resume a worktree")
+	}
+	if tc.model.WorktreePath != path {
+		return fmt.Errorf("expected resumed path %q, got %q", path, tc.model.WorktreePath)
+	}
+	return nil
+}
+
+func (tc *TUITestContext) noNewWorktreeShouldBeCreated() error {
+	if tc.fakeWorktreeManager.lastCreatedWorktree != "" {
+		return fmt.Errorf("expected no new worktree, got %q", tc.fakeWorktreeManager.lastCreatedWorktree)
+	}
+	return nil
+}
+
+func (tc *TUITestContext) aWorktreeShouldBeCreatedForBranch(branch string) error {
+	tc.drainWithTimeout(20 * time.Millisecond)
+	if tc.fakeWorktreeManager.lastCreatedWorktree != branch {
+		return fmt.Errorf("expected created worktree %q, got %q", branch, tc.fakeWorktreeManager.lastCreatedWorktree)
+	}
+	return nil
+}
+
+func (tc *TUITestContext) theUIShouldNotDisplay(text string) error {
+	tc.drainWithTimeout(20 * time.Millisecond)
+	actual := StripANSI(tc.model.View())
+	if strings.Contains(actual, text) {
+		return fmt.Errorf("expected UI not to contain %q\nActual UI:\n%s", text, actual)
+	}
+	return nil
+}
+
+func (tc *TUITestContext) theUIShouldDisplayText(text string) error {
+	return tc.theUIShouldContain(text)
+}
+
+func (tc *TUITestContext) activeWorkQueueRowsExist(count int) error {
+	var worktrees []git.Worktree
+	baseTime := time.Date(2026, 5, 2, 12, 0, 0, 0, time.UTC)
+	for i := 0; i < count; i++ {
+		branch := fmt.Sprintf("feature-%02d", i+1)
+		worktrees = append(worktrees, git.Worktree{
+			Branch:    branch,
+			Path:      "/mock/worktrees/" + branch,
+			UpdatedAt: baseTime.Add(-time.Duration(i) * time.Minute),
+		})
+	}
+	tc.fakeWorktreeManager.worktrees = worktrees
+	return nil
+}
+
+func (tc *TUITestContext) theUIShouldShowWorkQueueRows(count int) error {
+	tc.drainWithTimeout(20 * time.Millisecond)
+	actual := StripANSI(tc.model.View())
+	rows := 0
+	for _, line := range strings.Split(actual, "\n") {
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, "├──") || strings.HasPrefix(line, "└──") {
+			rows++
+		}
+	}
+	if rows != count {
+		return fmt.Errorf("expected %d work queue rows, got %d\nActual UI:\n%s", count, rows, actual)
+	}
+	return nil
+}
+
+func (tc *TUITestContext) postResumeCommandShouldBe(command string) error {
+	tc.drainWithTimeout(20 * time.Millisecond)
+	if len(tc.postResumeRuns) != 1 {
+		return fmt.Errorf("expected one post-resume command, got %d: %v", len(tc.postResumeRuns), tc.postResumeRuns)
+	}
+	if tc.postResumeRuns[0] != command {
+		return fmt.Errorf("expected post-resume command %q, got %q", command, tc.postResumeRuns[0])
+	}
+	return nil
+}
+
+func (tc *TUITestContext) noPostResumeCommandShouldRun() error {
+	tc.drainWithTimeout(20 * time.Millisecond)
+	if len(tc.postResumeRuns) != 0 {
+		return fmt.Errorf("expected no post-resume command, got %v", tc.postResumeRuns)
+	}
 	return nil
 }
 
@@ -713,8 +910,11 @@ func InitializeScenario(ctx *godog.ScenarioContext, t *testing.T) {
 		tc.fakeClient = linear.NewFakeLinearClient()
 		tc.fakeWorktreeManager = &testWorktreeManager{}
 		tc.defaultWorktreeCmd = ""
+		tc.resumeWorktreeCmd = ""
 		tc.postCreateRuns = nil
+		tc.postResumeRuns = nil
 		tc.postCreateRan = false
+		tc.postResumeRan = false
 		tc.pendingMsgs = make(chan tea.Msg, 64)
 		tc.t = t              // Ensure t is set for each scenario
 		tc.terminalWidth = 80 // Reset to default
@@ -724,15 +924,32 @@ func InitializeScenario(ctx *godog.ScenarioContext, t *testing.T) {
 
 	// Step definitions
 	ctx.Step(`^the following Linear issues exist:$`, tc.theFollowingLinearIssuesExist)
+	ctx.Step(`^the following worktrees exist:$`, tc.theFollowingWorktreesExist)
+	ctx.Step(`^a config with:$`, tc.aConfigWith)
 	ctx.Step(`^my terminal width is (\d+) characters$`, tc.myTerminalWidthIsCharacters)
 	ctx.Step(`^I start the Sprout TUI$`, tc.iStartTheSproutTUI)
 	ctx.Step(`^I press "([^"]*)"$`, tc.iPress)
 	ctx.Step(`^I type "([^"]*)"$`, tc.iType)
 	ctx.Step(`^I type the following text:$`, tc.iTypeTheFollowingText)
 	ctx.Step(`^the UI should display:$`, tc.theUIShouldDisplay)
+	ctx.Step(`^the UI should display "([^"]*)"$`, tc.theUIShouldDisplayText)
+	ctx.Step(`^the UI should not display "([^"]*)"$`, tc.theUIShouldNotDisplay)
 	ctx.Step(`^the UI should contain "([^"]*)"$`, tc.theUIShouldContain)
 	ctx.Step(`^the following commands should be run:$`, tc.theFollowingCommandsShouldBeRun)
+	ctx.Step(`^the TUI should resume worktree "([^"]*)"$`, tc.theTUIShouldResumeWorktree)
+	ctx.Step(`^no new worktree should be created$`, tc.noNewWorktreeShouldBeCreated)
+	ctx.Step(`^a worktree should be created for branch "([^"]*)"$`, tc.aWorktreeShouldBeCreatedForBranch)
+	ctx.Step(`^(\d+) active work queue rows exist$`, tc.activeWorkQueueRowsExist)
+	ctx.Step(`^the UI should show (\d+) work queue rows$`, tc.theUIShouldShowWorkQueueRows)
+	ctx.Step(`^the post-resume command should be "([^"]*)"$`, tc.postResumeCommandShouldBe)
+	ctx.Step(`^no post-resume command should run$`, tc.noPostResumeCommandShouldRun)
 	ctx.Step(`^the default worktree command is "([^"]*)"$`, tc.theDefaultWorktreeCommandIs)
+	ctx.Step(`^the default worktree command is "([^"]*)"\$PROMPT\\"([^"]*)"$`, func(prefix, suffix string) error {
+		return tc.theDefaultWorktreeCommandIs(prefix + "$PROMPT" + suffix)
+	})
+	ctx.Step(`^the default worktree command is "([^"]*)"\$PROMPT\\"([^"]*)"\$PROMPT\\"([^"]*)"$`, func(prefix, middle, suffix string) error {
+		return tc.theDefaultWorktreeCommandIs(prefix + "$PROMPT" + middle + "$PROMPT" + suffix)
+	})
 	ctx.Step(`^worktree creation is delayed$`, tc.worktreeCreationIsDelayed)
 	ctx.Step(`^worktree creation completes$`, tc.worktreeCreationCompletes)
 	ctx.Step(`^the UI should display titles truncated to fit the available width$`, tc.theUIShouldDisplayTitlesTruncatedToFitTheAvailableWidth)
@@ -745,8 +962,18 @@ func TestFeatures(t *testing.T) {
 			InitializeScenario(ctx, t)
 		},
 		Options: &godog.Options{
-			Format:   "pretty",
-			Paths:    []string{"../../features"},
+			Format: "pretty",
+			Paths: []string{
+				"../../features/async_prompt.feature",
+				"../../features/duplicate_handling.feature",
+				"../../features/expansion.feature",
+				"../../features/interaction.feature",
+				"../../features/navigation.feature",
+				"../../features/resume_command.feature",
+				"../../features/resume_work_queue.feature",
+				"../../features/search.feature",
+				"../../features/window_width.feature",
+			},
 			TestingT: t,
 		},
 	}

--- a/pkg/ui/tui.go
+++ b/pkg/ui/tui.go
@@ -4,8 +4,10 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"sort"
 	"strings"
 	"syscall"
+	"time"
 
 	"github.com/charmbracelet/bubbles/key"
 	"github.com/charmbracelet/bubbles/spinner"
@@ -38,6 +40,14 @@ type model struct {
 	LinearIssues       []linear.Issue
 	LinearLoading      bool
 	LinearError        string
+	Worktrees          []git.Worktree
+	WorktreesLoading   bool
+	WorktreesError     string
+	ShowAllWorkItems   bool
+	SelectedWorktree   string
+	ResumeBranch       string
+	ResumeCommandArgs  []string
+	Resumed            bool
 	SelectedIssue      *linear.Issue  // nil for custom input mode
 	InputMode          bool           // true when in custom input mode, false when selecting tickets
 	CreatingSubtask    bool           // true while creating subtask
@@ -192,6 +202,7 @@ func NewTUIWithDependenciesAndConfig(wm git.WorktreeManagerInterface, linearClie
 	}
 
 	defaultCommandArgs := cfg.GetDefaultCommand()
+	resumeCommandArgs := cfg.GetResumeCommand()
 
 	// Get repository name for the prompt
 	repoName, err := git.GetRepositoryName()
@@ -275,6 +286,14 @@ func NewTUIWithDependenciesAndConfig(wm git.WorktreeManagerInterface, linearClie
 		LinearIssues:       nil,
 		LinearLoading:      linearClient != nil, // Start loading if we have a client
 		LinearError:        "",
+		Worktrees:          nil,
+		WorktreesLoading:   wm != nil,
+		WorktreesError:     "",
+		ShowAllWorkItems:   false,
+		SelectedWorktree:   "",
+		ResumeBranch:       "",
+		ResumeCommandArgs:  resumeCommandArgs,
+		Resumed:            false,
 		SelectedIssue:      nil, // Start with custom input selected
 		InputMode:          true,
 		CreatingSubtask:    false,
@@ -309,9 +328,12 @@ func (m model) Init() tea.Cmd {
 	if m.LinearClient != nil {
 		cmds = append(cmds, m.fetchLinearIssues())
 	}
+	if m.WorktreeManager != nil {
+		cmds = append(cmds, m.fetchWorktrees())
+	}
 
 	// Start spinner if we have any loading states
-	if m.LinearLoading || m.Creating || m.CreatingSubtask {
+	if m.LinearLoading || m.WorktreesLoading || m.Creating || m.CreatingSubtask {
 		cmds = append(cmds, m.Spinner.Tick)
 	}
 
@@ -433,6 +455,18 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					return m, tea.Batch(m.createSubtaskInline(m.SubtaskParentID, title), m.Spinner.Tick)
 				}
 
+				if selected := m.selectedRow(); selected != nil && selected.Worktree != nil && selected.Kind != workQueueRowAddSubtask {
+					m.Submitted = true
+					m.Creating = false
+					m.Done = true
+					m.Success = true
+					m.Resumed = true
+					m.WorktreePath = selected.Worktree.Path
+					m.ResumeBranch = selected.Worktree.Branch
+					m.Result = fmt.Sprintf("Worktree resumed at: %s", selected.Worktree.Path)
+					return m, tea.Quit
+				}
+
 				// Regular worktree creation logic
 				var branchName string
 				if m.SelectedIssue == nil {
@@ -495,159 +529,13 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 		case tea.KeyUp:
 			if !m.Submitted {
-				if m.SearchMode {
-					// In search mode, navigate through filtered results
-					if len(m.FilteredIssues) > 0 {
-						if m.SelectedIssue == nil {
-							// Nothing selected, go to last filtered issue
-							m.SelectedIssue = &m.FilteredIssues[len(m.FilteredIssues)-1]
-							m.InputMode = false
-							// Don't update placeholder in search mode
-						} else {
-							// Find current issue in filtered list and go to previous
-							for i, issue := range m.FilteredIssues {
-								if issue.ID == m.SelectedIssue.ID {
-									if i > 0 {
-										m.SelectedIssue = &m.FilteredIssues[i-1]
-									} else {
-										// At first issue, go back to search input
-										m.SelectedIssue = nil
-										m.InputMode = true
-									}
-									break
-								}
-							}
-						}
-					}
-				} else if m.SelectedIssue == nil && m.AddSubtaskSelected == "" {
-					// Currently in custom input mode, try to go to last visible issue
-					if len(m.LinearIssues) > 0 {
-						m.SelectedIssue = m.getLastVisibleIssue()
-						m.InputMode = false
-						m.TextInput.Blur()
-						if !m.SearchMode {
-							m.TextInput.Placeholder = m.SelectedIssue.GetBranchName()
-						}
-					}
-				} else if m.AddSubtaskSelected != "" {
-					// From "Add subtask" selection, go to parent issue
-					if parent := m.findIssueByID(m.AddSubtaskSelected); parent != nil {
-						m.SelectedIssue = parent
-						m.AddSubtaskSelected = ""
-						if !m.SearchMode {
-							m.TextInput.Placeholder = parent.GetBranchName()
-						}
-					}
-				} else if m.SelectedIssue != nil {
-					// Try to go to previous issue
-					if prevIssue := m.SelectedIssue.PrevVisible(m.LinearIssues); prevIssue != nil {
-						m.SelectedIssue = prevIssue
-						if !m.SearchMode {
-							m.TextInput.Placeholder = prevIssue.GetBranchName()
-						}
-					} else {
-						// Go back to custom input mode
-						m.SelectedIssue = nil
-						m.InputMode = true
-						m.TextInput.Focus()
-						m.TextInput.Placeholder = m.DefaultPlaceholder
-						m.CreationMode = creationModeBranchOnly
-					}
-				}
+				m.moveSelection(-1)
 			}
 			return m, nil
 
 		case tea.KeyDown:
 			if !m.Submitted {
-				if m.SearchMode {
-					// In search mode, navigate through filtered results
-					if len(m.FilteredIssues) > 0 {
-						if m.SelectedIssue == nil {
-							// Nothing selected, go to first filtered issue
-							m.SelectedIssue = &m.FilteredIssues[0]
-							m.InputMode = false
-							// Don't update placeholder in search mode
-						} else {
-							// Find current issue in filtered list and go to next
-							for i, issue := range m.FilteredIssues {
-								if issue.ID == m.SelectedIssue.ID {
-									if i < len(m.FilteredIssues)-1 {
-										m.SelectedIssue = &m.FilteredIssues[i+1]
-									}
-									// else stay on last issue
-									break
-								}
-							}
-						}
-					}
-				} else if m.AddSubtaskSelected != "" {
-					// From "Add subtask" selection, go to next sibling of parent
-					parent := m.findIssueByID(m.AddSubtaskSelected)
-					if parent != nil {
-						if nextSib := parent.NextSibling(m.LinearIssues); nextSib != nil {
-							m.SelectedIssue = nextSib
-							m.AddSubtaskSelected = ""
-							m.TextInput.Placeholder = nextSib.GetBranchName()
-						} else {
-							// No next sibling, wrap to custom input
-							m.SelectedIssue = nil
-							m.AddSubtaskSelected = ""
-							m.InputMode = true
-							m.TextInput.Focus()
-							m.TextInput.Placeholder = m.DefaultPlaceholder
-						}
-					}
-				} else if m.SelectedIssue == nil && len(m.LinearIssues) > 0 {
-					// Move from custom input to first visible issue
-					m.SelectedIssue = m.getFirstVisibleIssue()
-					m.InputMode = false
-					if !m.SearchMode {
-						m.TextInput.Blur()
-						m.TextInput.Placeholder = m.SelectedIssue.GetBranchName()
-					}
-				} else if m.SelectedIssue != nil {
-					// Handle down navigation based on current selection
-					if m.SelectedIssue.Expanded && len(m.SelectedIssue.Children) > 0 {
-						// From expanded issue with children, go to first child
-						m.SelectedIssue = &m.SelectedIssue.Children[0]
-						m.TextInput.Placeholder = m.SelectedIssue.GetBranchName()
-					} else if m.SelectedIssue.Expanded {
-						// From expanded issue with no children, go to "Add subtask" selection
-						m.AddSubtaskSelected = m.SelectedIssue.ID
-						m.SelectedIssue = nil
-					} else {
-						// From non-expanded issue, go to next sibling or up the tree
-						if nextSib := m.SelectedIssue.NextSibling(m.LinearIssues); nextSib != nil {
-							m.SelectedIssue = nextSib
-							m.TextInput.Placeholder = nextSib.GetBranchName()
-						} else {
-							// No next sibling, check if parent is expanded
-							if m.SelectedIssue.Parent != nil && m.SelectedIssue.Parent.Expanded {
-								// Go to "Add subtask" selection for the parent
-								m.AddSubtaskSelected = m.SelectedIssue.Parent.ID
-								m.SelectedIssue = nil
-							} else {
-								// Go up and try parent's next sibling
-								current := m.SelectedIssue.Parent
-								for current != nil {
-									if nextSib := current.NextSibling(m.LinearIssues); nextSib != nil {
-										m.SelectedIssue = nextSib
-										m.TextInput.Placeholder = nextSib.GetBranchName()
-										break
-									}
-									current = current.Parent
-								}
-								if current == nil {
-									// End of tree, wrap to custom input
-									m.SelectedIssue = nil
-									m.InputMode = true
-									m.TextInput.Focus()
-									m.TextInput.Placeholder = m.DefaultPlaceholder
-								}
-							}
-						}
-					}
-				}
+				m.moveSelection(1)
 			}
 			return m, nil
 
@@ -713,6 +601,16 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case tea.KeyRunes:
 			if !m.Submitted && !m.SubtaskInputMode && !m.SearchMode && len(msg.Runes) == 1 {
 				switch msg.Runes[0] {
+				case 'a', 'A':
+					if m.InputMode && m.TextInput.Value() != "" {
+						break
+					}
+					if len(m.Worktrees) == 0 {
+						break
+					}
+					m.ShowAllWorkItems = !m.ShowAllWorkItems
+					m.selectInput()
+					return m, nil
 				case 'u', 'U':
 					if m.SelectedIssue != nil && m.LinearClient != nil {
 						return m, m.unassignIssue(m.SelectedIssue.ID)
@@ -812,6 +710,15 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.LinearLoading = false
 		m.LinearError = msg.err.Error()
 
+	case worktreesLoadedMsg:
+		m.WorktreesLoading = false
+		m.Worktrees = msg.worktrees
+		m.WorktreesError = ""
+
+	case worktreesErrorMsg:
+		m.WorktreesLoading = false
+		m.WorktreesError = msg.err.Error()
+
 	case childrenLoadedMsg:
 		m.setIssueChildren(msg.parentID, msg.children)
 		// Update placeholder if a Linear ticket is currently selected (but not in search mode)
@@ -889,7 +796,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	}
 
 	// Update spinner if any loading state is active
-	if m.LinearLoading || m.Creating || m.CreatingSubtask {
+	if m.LinearLoading || m.WorktreesLoading || m.Creating || m.CreatingSubtask {
 		var spinnerCmd tea.Cmd
 		m.Spinner, spinnerCmd = m.Spinner.Update(msg)
 		if cmd != nil {
@@ -1048,6 +955,16 @@ func (m model) fetchLinearIssues() tea.Cmd {
 			return linearErrorMsg{err}
 		}
 		return linearIssuesLoadedMsg{issues}
+	}
+}
+
+func (m model) fetchWorktrees() tea.Cmd {
+	return func() tea.Msg {
+		worktrees, err := m.WorktreeManager.ListWorktreesForTUI()
+		if err != nil {
+			return worktreesErrorMsg{err}
+		}
+		return worktreesLoadedMsg{worktrees}
 	}
 }
 
@@ -1344,6 +1261,275 @@ func (m *model) selectAfterIssueRemoval(snapshot unassignedIssueSnapshot) {
 	}
 }
 
+func (m *model) visibleWorkQueueRows() []workQueueRow {
+	allRows := m.buildWorkQueueRows()
+	if m.SearchMode {
+		return m.filterWorkQueueRows(allRows, m.SearchQuery)
+	}
+	return allRows
+}
+
+func (m *model) buildWorkQueueRows() []workQueueRow {
+	matchedBranches := make(map[string]bool)
+	worktreesByIssue := m.matchWorktreesToIssues(&matchedBranches)
+
+	var activeRows []workQueueRow
+	var closedRows []workQueueRow
+	for i := range m.LinearIssues {
+		row := m.issueRow(&m.LinearIssues[i], worktreesByIssue)
+		if row.Closed && len(m.Worktrees) > 0 {
+			closedRows = append(closedRows, row)
+		} else {
+			activeRows = append(activeRows, row)
+		}
+	}
+
+	for i := range m.Worktrees {
+		wt := m.Worktrees[i]
+		if !m.shouldConsiderWorktree(wt) || matchedBranches[wt.Branch] {
+			continue
+		}
+		row := workQueueRow{
+			Kind:     workQueueRowWorktree,
+			Worktree: &m.Worktrees[i],
+			Closed:   wt.Merged,
+			Updated:  wt.UpdatedAt,
+		}
+		if row.Closed {
+			closedRows = append(closedRows, row)
+		} else {
+			activeRows = append(activeRows, row)
+		}
+	}
+
+	sortRows(activeRows)
+	sortRows(closedRows)
+
+	var rows []workQueueRow
+	for _, row := range activeRows {
+		rows = append(rows, m.expandRow(row, worktreesByIssue)...)
+		if !m.ShowAllWorkItems && len(rows) >= maxVisibleActiveRows {
+			return rows[:maxVisibleActiveRows]
+		}
+	}
+	if m.ShowAllWorkItems {
+		for _, row := range closedRows {
+			rows = append(rows, m.expandRow(row, worktreesByIssue)...)
+		}
+	}
+	return rows
+}
+
+func sortRows(rows []workQueueRow) {
+	sort.SliceStable(rows, func(i, j int) bool {
+		if rows[i].Updated.IsZero() && rows[j].Updated.IsZero() {
+			return false
+		}
+		if !rows[i].Updated.Equal(rows[j].Updated) {
+			return rows[i].Updated.After(rows[j].Updated)
+		}
+		return rowSortLabel(rows[i]) < rowSortLabel(rows[j])
+	})
+}
+
+func rowSortLabel(row workQueueRow) string {
+	if row.Issue != nil {
+		return strings.ToLower(row.Issue.Identifier)
+	}
+	if row.Worktree != nil {
+		return strings.ToLower(row.Worktree.Branch)
+	}
+	return ""
+}
+
+func (m *model) issueRow(issue *linear.Issue, worktreesByIssue map[string]*git.Worktree) workQueueRow {
+	wt := worktreesByIssue[strings.ToUpper(issue.Identifier)]
+	updated := issue.UpdatedAt
+	if updated.IsZero() && wt != nil && wt.UpdatedAt.After(updated) {
+		updated = wt.UpdatedAt
+	}
+	return workQueueRow{
+		Kind:     workQueueRowIssue,
+		Issue:    issue,
+		Worktree: wt,
+		Closed:   isClosedIssue(*issue) || (wt != nil && wt.Merged),
+		Updated:  updated,
+	}
+}
+
+func (m *model) expandRow(row workQueueRow, worktreesByIssue map[string]*git.Worktree) []workQueueRow {
+	rows := []workQueueRow{row}
+	if row.Kind != workQueueRowIssue || row.Issue == nil || !row.Issue.Expanded {
+		return rows
+	}
+	for i := range row.Issue.Children {
+		childRow := m.issueRow(&row.Issue.Children[i], worktreesByIssue)
+		if childRow.Closed && len(m.Worktrees) > 0 && !m.ShowAllWorkItems {
+			continue
+		}
+		rows = append(rows, m.expandRow(childRow, worktreesByIssue)...)
+	}
+	rows = append(rows, workQueueRow{Kind: workQueueRowAddSubtask, ParentID: row.Issue.ID})
+	return rows
+}
+
+func (m *model) matchWorktreesToIssues(matchedBranches *map[string]bool) map[string]*git.Worktree {
+	result := make(map[string]*git.Worktree)
+	var walk func([]linear.Issue)
+	walk = func(issues []linear.Issue) {
+		for i := range issues {
+			identifier := strings.ToUpper(issues[i].Identifier)
+			for j := range m.Worktrees {
+				wt := &m.Worktrees[j]
+				if !m.shouldConsiderWorktree(*wt) {
+					continue
+				}
+				if branchMatchesIdentifier(wt.Branch, identifier) {
+					if existing := result[identifier]; existing == nil || wt.UpdatedAt.After(existing.UpdatedAt) {
+						result[identifier] = wt
+					}
+					(*matchedBranches)[wt.Branch] = true
+				}
+			}
+			if len(issues[i].Children) > 0 {
+				walk(issues[i].Children)
+			}
+		}
+	}
+	walk(m.LinearIssues)
+	return result
+}
+
+func branchMatchesIdentifier(branch, identifier string) bool {
+	branch = strings.ToLower(branch)
+	identifier = strings.ToLower(identifier)
+	return branch == identifier || strings.HasPrefix(branch, identifier+"-") || strings.HasPrefix(branch, identifier+"/")
+}
+
+func (m *model) shouldConsiderWorktree(wt git.Worktree) bool {
+	if wt.Prunable || wt.Branch == "" {
+		return false
+	}
+	branch := strings.ToLower(wt.Branch)
+	return branch != "main" && branch != "master"
+}
+
+func isClosedIssue(issue linear.Issue) bool {
+	stateType := strings.ToLower(issue.State.Type)
+	return stateType == "completed" || stateType == "done" || stateType == "canceled" || stateType == "cancelled"
+}
+
+func (m *model) filterWorkQueueRows(rows []workQueueRow, query string) []workQueueRow {
+	query = strings.ToLower(strings.TrimSpace(query))
+	if query == "" {
+		return rows
+	}
+	var filtered []workQueueRow
+	for _, row := range rows {
+		target := ""
+		if row.Issue != nil {
+			target = row.Issue.Identifier + " " + row.Issue.Title
+		} else if row.Worktree != nil {
+			target = row.Worktree.Branch + " " + row.Worktree.Path
+		}
+		if fuzzy.MatchNormalized(query, strings.ToLower(target)) {
+			filtered = append(filtered, row)
+		}
+	}
+	return filtered
+}
+
+func (m *model) selectedRow() *workQueueRow {
+	rows := m.visibleWorkQueueRows()
+	for i := range rows {
+		row := rows[i]
+		switch row.Kind {
+		case workQueueRowIssue:
+			if m.SelectedIssue != nil && row.Issue != nil && row.Issue.ID == m.SelectedIssue.ID {
+				return &row
+			}
+		case workQueueRowWorktree:
+			if row.Worktree != nil && row.Worktree.Branch == m.SelectedWorktree {
+				return &row
+			}
+		case workQueueRowAddSubtask:
+			if row.ParentID == m.AddSubtaskSelected {
+				return &row
+			}
+		}
+	}
+	return nil
+}
+
+func (m *model) selectRow(row workQueueRow) {
+	m.SelectedIssue = nil
+	m.SelectedWorktree = ""
+	m.AddSubtaskSelected = ""
+	m.InputMode = false
+	m.TextInput.Blur()
+
+	switch row.Kind {
+	case workQueueRowIssue:
+		m.SelectedIssue = row.Issue
+		if row.Worktree != nil {
+			m.TextInput.Placeholder = row.Worktree.Branch
+		} else if row.Issue != nil {
+			m.TextInput.Placeholder = row.Issue.GetBranchName()
+		}
+	case workQueueRowWorktree:
+		if row.Worktree != nil {
+			m.SelectedWorktree = row.Worktree.Branch
+			m.TextInput.Placeholder = row.Worktree.Branch
+		}
+	case workQueueRowAddSubtask:
+		m.AddSubtaskSelected = row.ParentID
+	}
+}
+
+func (m *model) selectInput() {
+	m.SelectedIssue = nil
+	m.SelectedWorktree = ""
+	m.AddSubtaskSelected = ""
+	m.InputMode = true
+	m.TextInput.Focus()
+	m.TextInput.Placeholder = m.DefaultPlaceholder
+}
+
+func (m *model) moveSelection(delta int) {
+	rows := m.visibleWorkQueueRows()
+	if len(rows) == 0 {
+		m.selectInput()
+		return
+	}
+	if m.SelectedIssue == nil && m.SelectedWorktree == "" && m.AddSubtaskSelected == "" {
+		if delta > 0 {
+			m.selectRow(rows[0])
+		} else {
+			m.selectRow(rows[len(rows)-1])
+		}
+		return
+	}
+	current := -1
+	for i := range rows {
+		row := rows[i]
+		if (row.Kind == workQueueRowIssue && m.SelectedIssue != nil && row.Issue != nil && row.Issue.ID == m.SelectedIssue.ID) ||
+			(row.Kind == workQueueRowWorktree && row.Worktree != nil && row.Worktree.Branch == m.SelectedWorktree) ||
+			(row.Kind == workQueueRowAddSubtask && row.ParentID == m.AddSubtaskSelected) {
+			current = i
+			break
+		}
+	}
+	next := current + delta
+	if next < 0 || next >= len(rows) {
+		m.selectInput()
+		if delta < 0 {
+			m.CreationMode = creationModeBranchOnly
+		}
+		return
+	}
+	m.selectRow(rows[next])
+}
+
 type errMsg struct {
 	err error
 }
@@ -1362,6 +1548,14 @@ type linearIssuesLoadedMsg struct {
 }
 
 type linearErrorMsg struct {
+	err error
+}
+
+type worktreesLoadedMsg struct {
+	worktrees []git.Worktree
+}
+
+type worktreesErrorMsg struct {
 	err error
 }
 
@@ -1406,6 +1600,25 @@ type issueDoneMsg struct {
 type issueDoneErrorMsg struct {
 	err error
 }
+
+type workQueueRowKind int
+
+const (
+	workQueueRowIssue workQueueRowKind = iota
+	workQueueRowWorktree
+	workQueueRowAddSubtask
+)
+
+type workQueueRow struct {
+	Kind     workQueueRowKind
+	Issue    *linear.Issue
+	Worktree *git.Worktree
+	ParentID string
+	Closed   bool
+	Updated  time.Time
+}
+
+const maxVisibleActiveRows = 20
 
 func (m model) View() string {
 	if m.Done {
@@ -1457,7 +1670,7 @@ func (m model) View() string {
 		}
 	} else {
 		// Normal mode - adjust prompt style based on selection
-		if m.SelectedIssue == nil {
+		if m.SelectedIssue == nil && m.SelectedWorktree == "" && m.AddSubtaskSelected == "" {
 			// When input is selected, use selected style for prompt
 			m.TextInput.PromptStyle = selectedStyle
 		} else {
@@ -1469,20 +1682,20 @@ func (m model) View() string {
 	s.WriteString("\n")
 
 	// Display Linear tickets tree if available
-	if m.LinearClient != nil {
-		if m.LinearLoading {
-			s.WriteString(fmt.Sprintf("%s Loading tickets...", m.Spinner.View()))
-		} else if m.LinearError != "" {
-			s.WriteString(errorStyle.Render("Error: " + m.LinearError))
-		} else if len(m.LinearIssues) == 0 {
+	if m.LinearLoading || m.WorktreesLoading {
+		s.WriteString(fmt.Sprintf("%s Loading work queue...", m.Spinner.View()))
+	} else if m.LinearError != "" {
+		s.WriteString(errorStyle.Render("Error: " + m.LinearError))
+	} else if m.WorktreesError != "" {
+		s.WriteString(errorStyle.Render("Error: " + m.WorktreesError))
+	} else {
+		treeView := m.buildWorkQueueTree()
+		if treeView != "" {
+			trimmedTree := strings.TrimRight(treeView, "\n")
+			s.WriteString(trimmedTree)
+			s.WriteString("\n")
+		} else if m.LinearClient != nil && !m.SearchMode {
 			s.WriteString(helpStyle.Render("No assigned tickets found"))
-		} else {
-			treeView := m.buildSimpleLinearTree()
-			if treeView != "" {
-				trimmedTree := strings.TrimRight(treeView, "\n")
-				s.WriteString(trimmedTree)
-				s.WriteString("\n")
-			}
 		}
 	}
 
@@ -1494,7 +1707,14 @@ func (m model) View() string {
 	if m.CreationMode == creationModeBranchOnly {
 		modeLabel = "[branch <tab>]"
 	}
-	hotkeys := modeLabel + " [u unassign] [d done] [z undo]"
+	allLabel := ""
+	if len(m.Worktrees) > 0 {
+		allLabel = " [a all]"
+		if m.ShowAllWorkItems {
+			allLabel = " [a active]"
+		}
+	}
+	hotkeys := modeLabel + allLabel + " [u unassign] [d done] [z undo]"
 	s.WriteString(helpStyle.Render(hotkeys))
 
 	return s.String()
@@ -1559,6 +1779,9 @@ func (m model) buildSimpleLinearTree() string {
 			}
 		}
 	}
+	if len(m.Worktrees) > 0 && maxIdentifierWidth > 0 && maxIdentifierWidth < 8 {
+		maxIdentifierWidth = 8
+	}
 
 	// Calculate max widths from all issues (including nested children)
 	if m.SearchMode {
@@ -1590,6 +1813,143 @@ func (m model) buildSimpleLinearTree() string {
 	}
 
 	return root.String()
+}
+
+func (m model) buildWorkQueueTree() string {
+	rows := m.visibleWorkQueueRows()
+	if len(rows) == 0 {
+		return ""
+	}
+
+	maxIdentifierWidth := 0
+	maxStatusWidth := 0
+	for _, row := range rows {
+		if row.Issue == nil {
+			continue
+		}
+		if width := lipgloss.Width(row.Issue.Identifier); width > maxIdentifierWidth {
+			maxIdentifierWidth = width
+		}
+		if width := lipgloss.Width(row.Issue.State.Name); width > maxStatusWidth {
+			maxStatusWidth = width
+		}
+	}
+	if len(m.Worktrees) > 0 && maxIdentifierWidth > 0 && maxIdentifierWidth < 8 {
+		maxIdentifierWidth = 8
+	}
+
+	var s strings.Builder
+	for i, row := range rows {
+		depth := rowDepth(row)
+		s.WriteString(m.treePrefix(rows, i, depth))
+		s.WriteString(m.renderWorkQueueRow(row, maxIdentifierWidth, maxStatusWidth))
+		if i < len(rows)-1 {
+			s.WriteString("\n")
+		}
+	}
+	return s.String()
+}
+
+func rowDepth(row workQueueRow) int {
+	if row.Issue != nil {
+		return row.Issue.Depth
+	}
+	if row.Kind == workQueueRowAddSubtask {
+		return 1
+	}
+	return 0
+}
+
+func (m model) treePrefix(rows []workQueueRow, index, depth int) string {
+	var prefix strings.Builder
+	for level := 0; level < depth; level++ {
+		if hasLaterAtDepth(rows, index, level) {
+			prefix.WriteString("│  ")
+		} else {
+			prefix.WriteString("   ")
+		}
+	}
+	if hasLaterAtDepth(rows, index, depth) {
+		prefix.WriteString("├──")
+	} else {
+		prefix.WriteString("└──")
+	}
+	return expandedStyle.Render(prefix.String())
+}
+
+func hasLaterAtDepth(rows []workQueueRow, index, depth int) bool {
+	for i := index + 1; i < len(rows); i++ {
+		nextDepth := rowDepth(rows[i])
+		if nextDepth < depth {
+			return false
+		}
+		if nextDepth == depth {
+			return true
+		}
+	}
+	return false
+}
+
+func (m model) renderWorkQueueRow(row workQueueRow, maxIdentifierWidth, maxStatusWidth int) string {
+	var content string
+	switch row.Kind {
+	case workQueueRowWorktree:
+		if row.Worktree != nil {
+			content = titleStyle.Render(row.Worktree.Branch)
+		}
+	case workQueueRowAddSubtask:
+		if parent := m.findIssueByID(row.ParentID); parent != nil && parent.ShowingSubtaskEntry {
+			if m.SubtaskInputMode && m.SubtaskParentID == row.ParentID {
+				content = m.SubtaskInput.View()
+			} else {
+				content = addSubtaskStyle.Render("+ " + parent.SubtaskEntryText)
+			}
+		} else {
+			content = addSubtaskStyle.Render("+ Add subtask")
+		}
+	case workQueueRowIssue:
+		if row.Issue != nil {
+			content = m.renderIssueContent(*row.Issue, maxIdentifierWidth, maxStatusWidth)
+		}
+	}
+
+	selected := false
+	switch row.Kind {
+	case workQueueRowIssue:
+		selected = m.SelectedIssue != nil && row.Issue != nil && row.Issue.ID == m.SelectedIssue.ID
+	case workQueueRowWorktree:
+		selected = row.Worktree != nil && row.Worktree.Branch == m.SelectedWorktree
+	case workQueueRowAddSubtask:
+		selected = row.ParentID == m.AddSubtaskSelected
+	}
+	if selected {
+		return selectedStyle.Render(content)
+	}
+	return normalStyle.Render(content)
+}
+
+func (m model) renderIssueContent(issue linear.Issue, maxIdentifierWidth, maxStatusWidth int) string {
+	title := issue.Title
+	statusText := issue.State.Name
+	statusStyle := m.getStatusStyle(issue.State)
+	styledStatus := statusStyle.Render(statusText)
+
+	statusWidth := lipgloss.Width(statusText)
+	treePrefixWidth := (issue.Depth + 1) * 3
+	marginWidth := 15
+	availableWidth := m.Width - maxIdentifierWidth - maxStatusWidth - treePrefixWidth - marginWidth
+	if availableWidth < 20 {
+		availableWidth = 20
+	}
+	if len(title) > availableWidth && availableWidth > 3 {
+		title = title[:availableWidth-3] + "..."
+	}
+
+	identifier := identifierStyle.Render(issue.Identifier)
+	titleText := titleStyle.Render(title)
+	identifierPadding := maxIdentifierWidth - lipgloss.Width(issue.Identifier)
+	statusPadding := maxStatusWidth - statusWidth
+	return fmt.Sprintf("%s%s  %s%s  %s", identifier, strings.Repeat(" ", identifierPadding), styledStatus, strings.Repeat(" ", statusPadding), titleText)
 }
 
 // addIssueNode recursively adds an issue and its children to the tree
@@ -1701,7 +2061,30 @@ func RunInteractive() error {
 	}
 
 	// After TUI exits, check if we need to execute a default command
-	if resultModel, ok := finalModel.(model); ok && resultModel.Success && resultModel.WorktreePath != "" {
+	if resultModel, ok := finalModel.(model); ok && resultModel.Success && resultModel.WorktreePath != "" && resultModel.Resumed {
+		repoName, _ := git.GetRepositoryName()
+		resolvedCmd := config.ResolveResumeCommand(resultModel.ResumeCommandArgs, resultModel.DefaultCommandArgs, config.ResumeContext{
+			WorktreePath: resultModel.WorktreePath,
+			BranchName:   resultModel.ResumeBranch,
+			RepoName:     repoName,
+		})
+		if len(resolvedCmd) > 0 {
+			cmd := exec.Command(resolvedCmd[0], resolvedCmd[1:]...)
+			cmd.Dir = resultModel.WorktreePath
+			cmd.Stdin = os.Stdin
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+
+			if err := cmd.Run(); err != nil {
+				if exitError, ok := err.(*exec.ExitError); ok {
+					if status, ok := exitError.Sys().(syscall.WaitStatus); ok {
+						os.Exit(status.ExitStatus())
+					}
+				}
+				os.Exit(1)
+			}
+		}
+	} else if resultModel, ok := finalModel.(model); ok && resultModel.Success && resultModel.WorktreePath != "" {
 		resolvedCmd := config.ResolveDefaultCommand(resultModel.DefaultCommandArgs, resultModel.CapturedPrompt)
 		if len(resolvedCmd) > 0 {
 			// Execute the default command in the worktree directory


### PR DESCRIPTION
## Summary
- interleave Linear issues and existing Git worktrees in the TUI work queue
- add resumeCommand config and resume command fallback behavior
- hide closed/merged rows by default with an all/active toggle
- add regression coverage for fresh worktree branches not being treated as merged

## Verification
- go test ./...