### PR TITLE
Fix subtask disclosure fetch failures

### DIFF
--- a/features/duplicate_handling.feature
+++ b/features/duplicate_handling.feature
@@ -47,3 +47,53 @@ Feature: Sprout duplicate issue handling
       └──TICK-4  In Review    Solo Task
       [worktree <tab>] [u unassign] [d done] [z undo]
       """
+
+  Scenario: Recently updated assigned subtasks keep their parent discoverable
+    Given the following Linear issues exist:
+      | identifier | title             | parent_id | status      | updated_at           |
+      | TICK-1     | Parent Task       |           | In Progress | 2026-05-01T08:00:00Z |
+      | TICK-2     | New Child Task    | TICK-1    | Todo        | 2026-05-02T12:00:00Z |
+      | TICK-3     | Other Recent Task |           | Todo        | 2026-05-02T10:00:00Z |
+    When I start the Sprout TUI
+    Then the UI should display:
+      """
+      🌱 sprout
+
+      > sprout/enter branch name or select suggestion below
+      ├──TICK-1  In Progress  Parent Task
+      └──TICK-3  Todo         Other Recent Task
+      [worktree <tab>] [u unassign] [d done] [z undo]
+      """
+    When I press "down"
+    And I press "right"
+    Then the UI should display:
+      """
+      🌱 sprout
+
+      > sprout/tick-1-parent-task
+      ├──TICK-1  In Progress  Parent Task
+      │  ├──TICK-2  Todo         New Child Task
+      │  └──+ Add subtask
+      └──TICK-3  Todo         Other Recent Task
+      [worktree <tab>] [u unassign] [d done] [z undo]
+      """
+
+  Scenario: Parent can still disclose add-subtask row when child loading fails
+    Given the following Linear issues exist:
+      | identifier | title       | parent_id | status      |
+      | TICK-1     | Parent Task |           | In Progress |
+      | TICK-2     | Child Task  | TICK-1    | Todo        |
+    And fetching children for "TICK-1" fails
+    And my terminal width is 120 characters
+    When I start the Sprout TUI
+    And I press "down"
+    And I press "right"
+    Then the UI should display:
+      """
+      🌱 sprout
+
+      > sprout/tick-1-parent-task
+      └──TICK-1  In Progress  Parent Task
+         └──+ Add subtask
+      [worktree <tab>] [u unassign] [d done] [z undo]                                      failed to fetch children for TICK-1
+      """

--- a/pkg/linear/client.go
+++ b/pkg/linear/client.go
@@ -269,6 +269,21 @@ func (c *Client) GetAssignedIssues() ([]Issue, error) {
 		}
 	}
 
+	// If an assigned child is folded under an assigned parent, keep the parent
+	// discoverable and sort it by the freshest hidden child activity.
+	for childID, parentID := range issueParents {
+		child := allIssues[childID]
+		parent := allIssues[parentID]
+		if parent.ID == "" {
+			continue
+		}
+		parent.HasChildren = true
+		if child.UpdatedAt.After(parent.UpdatedAt) {
+			parent.UpdatedAt = child.UpdatedAt
+		}
+		allIssues[parentID] = parent
+	}
+
 	// Second pass: filter out issues whose parents are also in the assigned list
 	// Process in order to maintain consistent results
 	var filteredIssues []Issue
@@ -726,6 +741,7 @@ type FakeLinearClient struct {
 	topLevelIssues []string            // IDs of root issues (no parent)
 	childrenMap    map[string][]string // parentID -> childIDs
 	currentUser    *User               // Simulated current user
+	childFetchErrs map[string]error
 }
 
 // NewFakeLinearClient creates a new fake Linear client for testing
@@ -734,6 +750,7 @@ func NewFakeLinearClient() *FakeLinearClient {
 		issues:         make(map[string]Issue),
 		topLevelIssues: []string{},
 		childrenMap:    make(map[string][]string),
+		childFetchErrs: make(map[string]error),
 		currentUser: &User{
 			ID:          "fake-user-id",
 			Name:        "Test User",
@@ -741,6 +758,11 @@ func NewFakeLinearClient() *FakeLinearClient {
 			Email:       "test@example.com",
 		},
 	}
+}
+
+// FailChildFetch causes GetIssueChildren to fail for the given issue ID.
+func (f *FakeLinearClient) FailChildFetch(issueID string, err error) {
+	f.childFetchErrs[issueID] = err
 }
 
 // AddIssue adds an issue to the fake client's data store
@@ -800,6 +822,21 @@ func (f *FakeLinearClient) GetAssignedIssues() ([]Issue, error) {
 		}
 	}
 
+	// If an assigned child is folded under an assigned parent, keep the parent
+	// discoverable and sort it by the freshest hidden child activity.
+	for childID, parentID := range issueParents {
+		child := allAssignedIssues[childID]
+		parent := allAssignedIssues[parentID]
+		if parent.ID == "" {
+			continue
+		}
+		parent.HasChildren = true
+		if child.UpdatedAt.After(parent.UpdatedAt) {
+			parent.UpdatedAt = child.UpdatedAt
+		}
+		allAssignedIssues[parentID] = parent
+	}
+
 	// Now filter out issues whose parents are also in the assigned list
 	// Process top-level issues in order to maintain consistent ordering
 	var filteredIssues []Issue
@@ -846,6 +883,10 @@ func (f *FakeLinearClient) GetAssignedIssues() ([]Issue, error) {
 
 // GetIssueChildren returns children for a given issue ID
 func (f *FakeLinearClient) GetIssueChildren(issueID string) ([]Issue, error) {
+	if err, exists := f.childFetchErrs[issueID]; exists {
+		return nil, err
+	}
+
 	childIDs, exists := f.childrenMap[issueID]
 	if !exists {
 		return []Issue{}, nil

--- a/pkg/ui/features_test.go
+++ b/pkg/ui/features_test.go
@@ -280,6 +280,11 @@ func (tc *TUITestContext) theFollowingWorktreesExist(worktreeTable *godog.Table)
 	return nil
 }
 
+func (tc *TUITestContext) fetchingChildrenForFails(identifier string) error {
+	tc.fakeClient.FailChildFetch(identifier, fmt.Errorf("failed to fetch children for %s", identifier))
+	return nil
+}
+
 func (tc *TUITestContext) iStartTheSproutTUI() error {
 	// Set consistent color profile for testing
 	lipgloss.SetColorProfile(termenv.Ascii)
@@ -925,6 +930,7 @@ func InitializeScenario(ctx *godog.ScenarioContext, t *testing.T) {
 	// Step definitions
 	ctx.Step(`^the following Linear issues exist:$`, tc.theFollowingLinearIssuesExist)
 	ctx.Step(`^the following worktrees exist:$`, tc.theFollowingWorktreesExist)
+	ctx.Step(`^fetching children for "([^"]*)" fails$`, tc.fetchingChildrenForFails)
 	ctx.Step(`^a config with:$`, tc.aConfigWith)
 	ctx.Step(`^my terminal width is (\d+) characters$`, tc.myTerminalWidthIsCharacters)
 	ctx.Step(`^I start the Sprout TUI$`, tc.iStartTheSproutTUI)

--- a/pkg/ui/tui.go
+++ b/pkg/ui/tui.go
@@ -40,6 +40,7 @@ type model struct {
 	LinearIssues       []linear.Issue
 	LinearLoading      bool
 	LinearError        string
+	FooterError        string
 	Worktrees          []git.Worktree
 	WorktreesLoading   bool
 	WorktreesError     string
@@ -286,6 +287,7 @@ func NewTUIWithDependenciesAndConfig(wm git.WorktreeManagerInterface, linearClie
 		LinearIssues:       nil,
 		LinearLoading:      linearClient != nil, // Start loading if we have a client
 		LinearError:        "",
+		FooterError:        "",
 		Worktrees:          nil,
 		WorktreesLoading:   wm != nil,
 		WorktreesError:     "",
@@ -720,6 +722,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.WorktreesError = msg.err.Error()
 
 	case childrenLoadedMsg:
+		m.FooterError = ""
 		m.setIssueChildren(msg.parentID, msg.children)
 		// Update placeholder if a Linear ticket is currently selected (but not in search mode)
 		if m.SelectedIssue != nil && !m.SearchMode {
@@ -727,7 +730,9 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 
 	case childrenErrorMsg:
-		// Could show error message or silently fail
+		// Still disclose the row so users can add a subtask even if child loading fails.
+		m.updateIssueExpansion(msg.parentID, true)
+		m.FooterError = msg.err.Error()
 
 	case subtaskCreatedMsg:
 		m.CreatingSubtask = false
@@ -972,7 +977,7 @@ func (m model) fetchChildren(issueID string) tea.Cmd {
 	return func() tea.Msg {
 		children, err := m.LinearClient.GetIssueChildren(issueID)
 		if err != nil {
-			return childrenErrorMsg{err}
+			return childrenErrorMsg{parentID: issueID, err: err}
 		}
 		return childrenLoadedMsg{issueID, children}
 	}
@@ -1565,7 +1570,8 @@ type childrenLoadedMsg struct {
 }
 
 type childrenErrorMsg struct {
-	err error
+	parentID string
+	err      error
 }
 
 type subtaskCreatedMsg struct {
@@ -1715,9 +1721,27 @@ func (m model) View() string {
 		}
 	}
 	hotkeys := modeLabel + allLabel + " [u unassign] [d done] [z undo]"
-	s.WriteString(helpStyle.Render(hotkeys))
+	s.WriteString(helpStyle.Render(m.renderFooter(hotkeys)))
 
 	return s.String()
+}
+
+func (m model) renderFooter(hotkeys string) string {
+	if m.FooterError == "" {
+		return hotkeys
+	}
+
+	if m.Width <= 0 {
+		return hotkeys + "\n" + m.FooterError
+	}
+
+	hotkeysWidth := lipgloss.Width(hotkeys)
+	errorWidth := lipgloss.Width(m.FooterError)
+	if hotkeysWidth+1+errorWidth <= m.Width {
+		return hotkeys + strings.Repeat(" ", m.Width-hotkeysWidth-errorWidth) + m.FooterError
+	}
+
+	return hotkeys + "\n" + m.FooterError
 }
 
 func (m model) renderPromptCaptureView() string {


### PR DESCRIPTION
## Summary
- keep assigned parents discoverable when assigned subtasks are folded into them
- disclose the add-subtask row even when loading existing subtasks fails
- show the child-loading error in the footer and cover the behavior in BDD tests