### PR TITLE
Parallelize and cache worktree PR status checks

### DIFF
--- a/features/work_queue_loading.feature
+++ b/features/work_queue_loading.feature
@@ -52,3 +52,9 @@ Feature: Work queue loading status
     Then the UI should display "Error:"
     And the UI should display "gh pr list --head feature-search --state all --json state --limit 1"
     And the UI should not show work queue rows
+
+  Scenario: Cached merged worktree skips GitHub lookup
+    Given worktree "feature-search" is cached as merged at its current commit
+    When I start the Sprout TUI
+    Then the UI should not display "gh pr list --head feature-search --state all --json state --limit 1"
+    And the UI should not display "feature-search"

--- a/pkg/git/worktree.go
+++ b/pkg/git/worktree.go
@@ -6,6 +6,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"sync"
 	"time"
 
 	"sprout/pkg/config"
@@ -320,24 +321,97 @@ func (wm *WorktreeManager) ListWorktreesForTUIWithProgress(progress func(string)
 				worktrees[i].UpdatedAt = info.ModTime()
 			}
 		}
+	}
 
-		if !shouldCheckPRStatusForTUI(worktrees[i]) || wm.githubClient == nil {
-			continue
-		}
-
-		command := github.PRStatusCommand(worktrees[i].Branch)
-		reportProgress(progress, command)
-		prStatus, err := wm.githubClient.GetPRStatusFromGH(worktrees[i].Branch)
-		if err != nil {
-			return nil, err
-		}
-		worktrees[i].PRStatus = prStatus
-		if prStatus == "Merged" {
-			worktrees[i].Merged = true
-		}
+	if err := wm.applyTUIWorktreePRStatuses(worktrees, progress); err != nil {
+		return nil, err
 	}
 
 	return worktrees, nil
+}
+
+const maxConcurrentTUIStatusChecks = 6
+
+type prStatusJob struct {
+	index int
+}
+
+type prStatusResult struct {
+	index  int
+	status string
+	err    error
+}
+
+func (wm *WorktreeManager) applyTUIWorktreePRStatuses(worktrees []Worktree, progress func(string)) error {
+	if wm.githubClient == nil {
+		return nil
+	}
+
+	var jobs []prStatusJob
+	for i := range worktrees {
+		if !shouldCheckPRStatusForTUI(worktrees[i]) {
+			continue
+		}
+		if wm.githubClient.CachedMergedPRStatus(worktrees[i].Branch, worktrees[i].Commit) {
+			worktrees[i].PRStatus = "Merged"
+			worktrees[i].Merged = true
+			continue
+		}
+		jobs = append(jobs, prStatusJob{index: i})
+	}
+	if len(jobs) == 0 {
+		return nil
+	}
+
+	workerCount := maxConcurrentTUIStatusChecks
+	if len(jobs) < workerCount {
+		workerCount = len(jobs)
+	}
+
+	jobCh := make(chan prStatusJob)
+	resultCh := make(chan prStatusResult, len(jobs))
+	var wg sync.WaitGroup
+
+	for i := 0; i < workerCount; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for job := range jobCh {
+				wt := worktrees[job.index]
+				command := github.PRStatusCommand(wt.Branch)
+				reportProgress(progress, command)
+				status, err := wm.githubClient.GetPRStatusFromGH(wt.Branch)
+				resultCh <- prStatusResult{index: job.index, status: status, err: err}
+			}
+		}()
+	}
+
+	go func() {
+		for _, job := range jobs {
+			jobCh <- job
+		}
+		close(jobCh)
+		wg.Wait()
+		close(resultCh)
+	}()
+
+	var firstErr error
+	for result := range resultCh {
+		if result.err != nil && firstErr == nil {
+			firstErr = result.err
+			continue
+		}
+		if result.err != nil {
+			continue
+		}
+		worktrees[result.index].PRStatus = result.status
+		if result.status == "Merged" {
+			worktrees[result.index].Merged = true
+			wm.githubClient.RememberMergedPRStatus(worktrees[result.index].Branch, worktrees[result.index].Commit)
+		}
+	}
+
+	return firstErr
 }
 
 func reportProgress(progress func(string), status string) {

--- a/pkg/git/worktree_test.go
+++ b/pkg/git/worktree_test.go
@@ -6,7 +6,9 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"sprout/pkg/config"
 	"sprout/pkg/github"
@@ -471,17 +473,92 @@ func TestListWorktreesForTUIGitHubFailureIncludesExactCommand(t *testing.T) {
 	}
 }
 
+func TestListWorktreesForTUIChecksGitHubStatusesInParallel(t *testing.T) {
+	tempDir, cleanup := setupRepoWithFeatureWorktrees(t, "feature-one", "feature-two")
+	defer cleanup()
+
+	var active int32
+	var maxActive int32
+	wm := &WorktreeManager{
+		repoRoot: tempDir,
+		githubClient: github.NewClientWithRunnerAndCachePath(tempDir, func(dir string, name string, args ...string) ([]byte, error) {
+			current := atomic.AddInt32(&active, 1)
+			for {
+				max := atomic.LoadInt32(&maxActive)
+				if current <= max || atomic.CompareAndSwapInt32(&maxActive, max, current) {
+					break
+				}
+			}
+			time.Sleep(50 * time.Millisecond)
+			atomic.AddInt32(&active, -1)
+			return []byte(`[{"state":"OPEN"}]`), nil
+		}, filepath.Join(t.TempDir(), "cache.json")),
+	}
+
+	if _, err := wm.ListWorktreesForTUIWithProgress(nil); err != nil {
+		t.Fatalf("ListWorktreesForTUIWithProgress returned error: %v", err)
+	}
+
+	if atomic.LoadInt32(&maxActive) < 2 {
+		t.Fatalf("expected concurrent GitHub checks, max active was %d", maxActive)
+	}
+}
+
+func TestListWorktreesForTUISkipsGitHubLookupForCachedMergedBranch(t *testing.T) {
+	tempDir, cleanup := setupRepoWithFeatureWorktree(t, "feature-search")
+	defer cleanup()
+
+	cachePath := filepath.Join(t.TempDir(), "cache.json")
+	var calls int32
+	wm := &WorktreeManager{
+		repoRoot: tempDir,
+		githubClient: github.NewClientWithRunnerAndCachePath(tempDir, func(dir string, name string, args ...string) ([]byte, error) {
+			atomic.AddInt32(&calls, 1)
+			return []byte(`[{"state":"OPEN"}]`), nil
+		}, cachePath),
+	}
+	commit := currentCommit(t, tempDir, "feature-search")
+	wm.githubClient.RememberMergedPRStatus("feature-search", commit)
+
+	worktrees, err := wm.ListWorktreesForTUIWithProgress(nil)
+	if err != nil {
+		t.Fatalf("ListWorktreesForTUIWithProgress returned error: %v", err)
+	}
+	if calls != 0 {
+		t.Fatalf("expected no GitHub calls for cached merged branch, got %d", calls)
+	}
+
+	for _, wt := range worktrees {
+		if wt.Branch == "feature-search" {
+			if !wt.Merged || wt.PRStatus != "Merged" {
+				t.Fatalf("expected cached merged branch to be marked merged, got %#v", wt)
+			}
+			return
+		}
+	}
+	t.Fatalf("feature-search worktree was not returned: %#v", worktrees)
+}
+
 func setupRepoWithFeatureWorktree(t *testing.T, branch string) (string, func()) {
+	return setupRepoWithFeatureWorktrees(t, branch)
+}
+
+func setupRepoWithFeatureWorktrees(t *testing.T, branches ...string) (string, func()) {
 	t.Helper()
 
 	tempDir, err := os.MkdirTemp("", "sprout-tui-worktree-*")
 	if err != nil {
 		t.Fatalf("Failed to create temp dir: %v", err)
 	}
-	worktreePath := filepath.Join(filepath.Dir(tempDir), branch)
+	var worktreePaths []string
+	for _, branch := range branches {
+		worktreePaths = append(worktreePaths, filepath.Join(filepath.Dir(tempDir), branch))
+	}
 	cleanup := func() {
 		os.RemoveAll(tempDir)
-		os.RemoveAll(worktreePath)
+		for _, worktreePath := range worktreePaths {
+			os.RemoveAll(worktreePath)
+		}
 	}
 
 	runGit(t, tempDir, "init")
@@ -495,9 +572,22 @@ func setupRepoWithFeatureWorktree(t *testing.T, branch string) (string, func()) 
 	}
 	runGit(t, tempDir, "add", ".")
 	runGit(t, tempDir, "commit", "-m", "Initial commit")
-	runGit(t, tempDir, "worktree", "add", worktreePath, "-b", branch, "master")
+	for i, branch := range branches {
+		runGit(t, tempDir, "worktree", "add", worktreePaths[i], "-b", branch, "master")
+	}
 
 	return tempDir, cleanup
+}
+
+func currentCommit(t *testing.T, dir string, branch string) string {
+	t.Helper()
+	cmd := exec.Command("git", "rev-parse", branch)
+	cmd.Dir = dir
+	output, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("failed to read commit for %s: %v", branch, err)
+	}
+	return strings.TrimSpace(string(output))
 }
 
 func runGit(t *testing.T, dir string, args ...string) {

--- a/pkg/github/pr.go
+++ b/pkg/github/pr.go
@@ -3,7 +3,9 @@ package github
 import (
 	"encoding/json"
 	"fmt"
+	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 )
 
@@ -15,6 +17,7 @@ type PR struct {
 type Client struct {
 	repoRoot string
 	runner   commandRunner
+	cache    *PRStatusCache
 }
 
 type commandRunner func(dir string, name string, args ...string) ([]byte, error)
@@ -23,6 +26,7 @@ func NewClient(repoRoot string) *Client {
 	return &Client{
 		repoRoot: repoRoot,
 		runner:   runCommandOutput,
+		cache:    NewPRStatusCache(repoRoot),
 	}
 }
 
@@ -33,7 +37,14 @@ func NewClientWithRunner(repoRoot string, runner commandRunner) *Client {
 	return &Client{
 		repoRoot: repoRoot,
 		runner:   runner,
+		cache:    NewPRStatusCache(repoRoot),
 	}
+}
+
+func NewClientWithRunnerAndCachePath(repoRoot string, runner commandRunner, cachePath string) *Client {
+	client := NewClientWithRunner(repoRoot, runner)
+	client.cache = NewPRStatusCacheWithPath(repoRoot, cachePath)
+	return client
 }
 
 func runCommandOutput(dir string, name string, args ...string) ([]byte, error) {
@@ -136,6 +147,16 @@ func PRStatusCommand(branchName string) string {
 	return fmt.Sprintf("gh pr list --head %s --state all --json state --limit 1", branchName)
 }
 
+func (c *Client) CachedMergedPRStatus(branchName, commit string) bool {
+	return c.cache != nil && c.cache.IsMerged(branchName, commit)
+}
+
+func (c *Client) RememberMergedPRStatus(branchName, commit string) {
+	if c.cache != nil {
+		c.cache.RememberMerged(branchName, commit)
+	}
+}
+
 func (c *Client) GetPRStatusFromGH(branchName string) (string, error) {
 	if branchName == "" || branchName == "master" || branchName == "main" {
 		return "-", nil
@@ -165,4 +186,87 @@ func (c *Client) GetPRStatusFromGH(branchName string) (string, error) {
 	default:
 		return prs[0].State, nil
 	}
+}
+
+type PRStatusCache struct {
+	repoRoot string
+	path     string
+}
+
+type prStatusCacheFile struct {
+	Repos map[string]map[string]string `json:"repos"`
+}
+
+func NewPRStatusCache(repoRoot string) *PRStatusCache {
+	cacheDir, err := os.UserCacheDir()
+	if err != nil {
+		return nil
+	}
+	return NewPRStatusCacheWithPath(repoRoot, filepath.Join(cacheDir, "sprout", "pr-status-cache.json"))
+}
+
+func NewPRStatusCacheWithPath(repoRoot, path string) *PRStatusCache {
+	if path == "" {
+		return nil
+	}
+	return &PRStatusCache{
+		repoRoot: repoRoot,
+		path:     path,
+	}
+}
+
+func (c *PRStatusCache) IsMerged(branchName, commit string) bool {
+	if c == nil || branchName == "" || commit == "" {
+		return false
+	}
+	cacheFile, err := c.load()
+	if err != nil {
+		return false
+	}
+	return cacheFile.Repos[c.repoRoot][branchName] == commit
+}
+
+func (c *PRStatusCache) RememberMerged(branchName, commit string) {
+	if c == nil || branchName == "" || commit == "" {
+		return
+	}
+
+	cacheFile, err := c.load()
+	if err != nil {
+		cacheFile = prStatusCacheFile{Repos: make(map[string]map[string]string)}
+	}
+	if cacheFile.Repos == nil {
+		cacheFile.Repos = make(map[string]map[string]string)
+	}
+	if cacheFile.Repos[c.repoRoot] == nil {
+		cacheFile.Repos[c.repoRoot] = make(map[string]string)
+	}
+	cacheFile.Repos[c.repoRoot][branchName] = commit
+	_ = c.save(cacheFile)
+}
+
+func (c *PRStatusCache) load() (prStatusCacheFile, error) {
+	cacheFile := prStatusCacheFile{Repos: make(map[string]map[string]string)}
+	data, err := os.ReadFile(c.path)
+	if err != nil {
+		return cacheFile, err
+	}
+	if err := json.Unmarshal(data, &cacheFile); err != nil {
+		return cacheFile, err
+	}
+	if cacheFile.Repos == nil {
+		cacheFile.Repos = make(map[string]map[string]string)
+	}
+	return cacheFile, nil
+}
+
+func (c *PRStatusCache) save(cacheFile prStatusCacheFile) error {
+	if err := os.MkdirAll(filepath.Dir(c.path), 0755); err != nil {
+		return err
+	}
+	data, err := json.MarshalIndent(cacheFile, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(c.path, data, 0644)
 }

--- a/pkg/ui/features_test.go
+++ b/pkg/ui/features_test.go
@@ -66,6 +66,7 @@ type testWorktreeManager struct {
 	createUnblock       chan struct{}
 	pauseStatus         string
 	failPRBranch        string
+	cachedMerged        map[string]bool
 }
 
 func (m *testWorktreeManager) CreateWorktree(branchName string) (string, error) {
@@ -118,6 +119,17 @@ func (m *testWorktreeManager) ListWorktreesForTUIWithProgress(progress func(stri
 			progress(command)
 		}
 		return nil, fmt.Errorf("%s: failed", command)
+	}
+	for i := range m.worktrees {
+		if m.cachedMerged[m.worktrees[i].Branch] {
+			m.worktrees[i].Merged = true
+			m.worktrees[i].PRStatus = "Merged"
+			continue
+		}
+		command := fmt.Sprintf("gh pr list --head %s --state all --json state --limit 1", m.worktrees[i].Branch)
+		if progress != nil {
+			progress(command)
+		}
 	}
 	return m.worktrees, nil
 }
@@ -953,6 +965,19 @@ func (tc *TUITestContext) githubPRStatusLookupFailsForBranch(branch string) erro
 	return nil
 }
 
+func (tc *TUITestContext) worktreeIsCachedAsMergedAtItsCurrentCommit(branch string) error {
+	if tc.fakeWorktreeManager.cachedMerged == nil {
+		tc.fakeWorktreeManager.cachedMerged = make(map[string]bool)
+	}
+	tc.fakeWorktreeManager.cachedMerged[branch] = true
+	tc.fakeWorktreeManager.worktrees = []git.Worktree{{
+		Branch: branch,
+		Path:   "/mock/worktrees/" + branch,
+		Commit: "cached-commit",
+	}}
+	return nil
+}
+
 func (tc *TUITestContext) postResumeCommandShouldBe(command string) error {
 	tc.drainWithTimeout(20 * time.Millisecond)
 	if len(tc.postResumeRuns) != 1 {
@@ -989,7 +1014,7 @@ func InitializeScenario(ctx *godog.ScenarioContext, t *testing.T) {
 	// Setup a test context for each scenario
 	ctx.Before(func(ctx context.Context, sc *godog.Scenario) (context.Context, error) {
 		tc.fakeLinear = lineartest.NewServer(t)
-		tc.fakeWorktreeManager = &testWorktreeManager{}
+		tc.fakeWorktreeManager = &testWorktreeManager{cachedMerged: make(map[string]bool)}
 		tc.defaultWorktreeCmd = ""
 		tc.resumeWorktreeCmd = ""
 		tc.postCreateRuns = nil
@@ -1030,6 +1055,7 @@ func InitializeScenario(ctx *godog.ScenarioContext, t *testing.T) {
 	ctx.Step(`^worktree loading has completed$`, tc.worktreeLoadingHasCompleted)
 	ctx.Step(`^Linear issue loading completes$`, tc.linearIssueLoadingCompletes)
 	ctx.Step(`^GitHub PR status lookup fails for branch "([^"]*)"$`, tc.githubPRStatusLookupFailsForBranch)
+	ctx.Step(`^worktree "([^"]*)" is cached as merged at its current commit$`, tc.worktreeIsCachedAsMergedAtItsCurrentCommit)
 	ctx.Step(`^the post-resume command should be "([^"]*)"$`, tc.postResumeCommandShouldBe)
 	ctx.Step(`^no post-resume command should run$`, tc.noPostResumeCommandShouldRun)
 	ctx.Step(`^the default worktree command is "([^"]*)"$`, tc.theDefaultWorktreeCommandIs)


### PR DESCRIPTION
## Summary
- check worktree GitHub PR statuses in a bounded parallel worker pool
- persist known merged branch statuses by repo, branch, and commit SHA
- skip GitHub lookup for cached merged worktrees while preserving queue stability
- add BDD coverage for cached merged worktrees skipping the gh lookup