### PR TITLE
Cache PR status results with jittered TTL and async refresh

### DIFF
--- a/pkg/git/worktree.go
+++ b/pkg/git/worktree.go
@@ -506,10 +506,6 @@ func parseWorktreeList(output string) []Worktree {
 	return worktrees
 }
 
-func (wm *WorktreeManager) branchCommitTimes() map[string]time.Time {
-	return wm.branchCommitTimesFor(nil, nil)
-}
-
 func (wm *WorktreeManager) branchCommitTimesFor(branches []string, progress func(string)) map[string]time.Time {
 	result := make(map[string]time.Time)
 	args := branchCommitTimesCommandArgs(branches)
@@ -552,103 +548,6 @@ func branchCommitTimesCommandArgs(branches []string) []string {
 		}
 	}
 	return append(args, "--format=%(refname:short)%00%(committerdate:iso-strict)")
-}
-
-func (wm *WorktreeManager) mergedBranches() map[string]bool {
-	result := make(map[string]bool)
-	baseBranch := wm.getCachedBaseBranch()
-	if baseBranch == "" {
-		return result
-	}
-	remoteBranches := wm.remoteBranches()
-	pushedBranches := wm.pushedBranchEvidence()
-	cmd := exec.Command("git", "branch", "--merged", baseBranch, "--format=%(refname:short)")
-	cmd.Dir = wm.repoRoot
-	output, err := cmd.Output()
-	if err != nil {
-		return result
-	}
-	for _, line := range strings.Split(string(output), "\n") {
-		branch := strings.TrimSpace(strings.TrimPrefix(line, "*"))
-		if branch != "" && (remoteBranches[branch] || pushedBranches[branch]) {
-			result[branch] = true
-		}
-	}
-	return result
-}
-
-func (wm *WorktreeManager) remoteBranches() map[string]bool {
-	result := make(map[string]bool)
-	cmd := exec.Command("git", "for-each-ref", "refs/remotes/origin", "--format=%(refname:short)")
-	cmd.Dir = wm.repoRoot
-	output, err := cmd.Output()
-	if err != nil {
-		return result
-	}
-	for _, line := range strings.Split(string(output), "\n") {
-		remoteBranch := strings.TrimSpace(line)
-		if strings.HasPrefix(remoteBranch, "origin/") {
-			branch := strings.TrimPrefix(remoteBranch, "origin/")
-			if branch != "HEAD" && branch != "" {
-				result[branch] = true
-			}
-		}
-	}
-	return result
-}
-
-func (wm *WorktreeManager) pushedBranchEvidence() map[string]bool {
-	result := make(map[string]bool)
-	cmd := exec.Command("git", "reflog", "--all", "--oneline")
-	cmd.Dir = wm.repoRoot
-	output, err := cmd.Output()
-	if err != nil {
-		return result
-	}
-	for _, line := range strings.Split(string(output), "\n") {
-		for _, field := range strings.Fields(line) {
-			if strings.HasPrefix(field, "origin/") {
-				branch := strings.Trim(strings.TrimPrefix(field, "origin/"), ":,;)")
-				if branch != "" && branch != "HEAD" {
-					result[branch] = true
-				}
-			}
-		}
-	}
-	return result
-}
-
-func (wm *WorktreeManager) getCachedBaseBranch() string {
-	cmd := exec.Command("git", "symbolic-ref", "refs/remotes/origin/HEAD")
-	cmd.Dir = wm.repoRoot
-	if output, err := cmd.Output(); err == nil {
-		ref := strings.TrimSpace(string(output))
-		const prefix = "refs/remotes/origin/"
-		if strings.HasPrefix(ref, prefix) {
-			branch := strings.TrimPrefix(ref, prefix)
-			if wm.branchExists("refs/remotes/origin/" + branch) {
-				return "origin/" + branch
-			}
-			if wm.branchExists("refs/heads/" + branch) {
-				return branch
-			}
-		}
-	}
-
-	for _, ref := range []struct {
-		verify string
-		name   string
-	}{
-		{"refs/heads/main", "main"},
-		{"refs/heads/master", "master"},
-		{"refs/remotes/origin/main", "origin/main"},
-		{"refs/remotes/origin/master", "origin/master"},
-	} {
-		if wm.branchExists(ref.verify) {
-			return ref.name
-		}
-	}
-	return ""
 }
 
 func (wm *WorktreeManager) getBaseBranch() (string, error) {

--- a/pkg/git/worktree.go
+++ b/pkg/git/worktree.go
@@ -352,12 +352,18 @@ func (wm *WorktreeManager) applyTUIWorktreePRStatuses(worktrees []Worktree, prog
 		if !shouldCheckPRStatusForTUI(worktrees[i]) {
 			continue
 		}
-		if wm.githubClient.CachedMergedPRStatus(worktrees[i].Branch, worktrees[i].Commit) {
-			worktrees[i].PRStatus = "Merged"
-			worktrees[i].Merged = true
-			continue
+		status, state := wm.githubClient.CachedPRStatus(worktrees[i].Branch, worktrees[i].Commit)
+		switch state {
+		case github.CacheFresh:
+			applyPRStatus(&worktrees[i], status)
+		case github.CacheStale:
+			// Serve the cached value now to keep the hot path fast, then
+			// refresh in the background so the next run reads fresh data.
+			applyPRStatus(&worktrees[i], status)
+			wm.refreshPRStatusInBackground(worktrees[i].Branch, worktrees[i].Commit)
+		default:
+			jobs = append(jobs, prStatusJob{index: i})
 		}
-		jobs = append(jobs, prStatusJob{index: i})
 	}
 	if len(jobs) == 0 {
 		return nil
@@ -397,21 +403,35 @@ func (wm *WorktreeManager) applyTUIWorktreePRStatuses(worktrees []Worktree, prog
 
 	var firstErr error
 	for result := range resultCh {
-		if result.err != nil && firstErr == nil {
-			firstErr = result.err
-			continue
-		}
 		if result.err != nil {
+			if firstErr == nil {
+				firstErr = result.err
+			}
 			continue
 		}
-		worktrees[result.index].PRStatus = result.status
-		if result.status == "Merged" {
-			worktrees[result.index].Merged = true
-			wm.githubClient.RememberMergedPRStatus(worktrees[result.index].Branch, worktrees[result.index].Commit)
-		}
+		applyPRStatus(&worktrees[result.index], result.status)
+		wm.githubClient.RememberPRStatus(worktrees[result.index].Branch, worktrees[result.index].Commit, result.status)
 	}
 
 	return firstErr
+}
+
+// applyPRStatus records a resolved PR status on a worktree.
+func applyPRStatus(wt *Worktree, status string) {
+	wt.PRStatus = status
+	wt.Merged = status == "Merged"
+}
+
+// refreshPRStatusInBackground re-checks a branch's PR status without blocking
+// the caller and updates the cache so the next run reads fresh data.
+func (wm *WorktreeManager) refreshPRStatusInBackground(branch, commit string) {
+	go func() {
+		status, err := wm.githubClient.GetPRStatusFromGH(branch)
+		if err != nil {
+			return
+		}
+		wm.githubClient.RememberPRStatus(branch, commit, status)
+	}()
 }
 
 func reportProgress(progress func(string), status string) {

--- a/pkg/git/worktree_test.go
+++ b/pkg/git/worktree_test.go
@@ -390,10 +390,10 @@ func TestListWorktreesForTUIUsesGitHubMergedStateForSquashAndDeletedRemoteBranch
 	commands := []string{}
 	wm := &WorktreeManager{
 		repoRoot: tempDir,
-		githubClient: github.NewClientWithRunner(tempDir, func(dir string, name string, args ...string) ([]byte, error) {
+		githubClient: github.NewClientWithRunnerAndCachePath(tempDir, func(dir string, name string, args ...string) ([]byte, error) {
 			commands = append(commands, name+" "+strings.Join(args, " "))
 			return []byte(`[{"state":"MERGED"}]`), nil
-		}),
+		}, filepath.Join(t.TempDir(), "cache.json")),
 	}
 
 	worktrees, err := wm.ListWorktreesForTUIWithProgress(nil)
@@ -434,9 +434,9 @@ func TestListWorktreesForTUIKeepsOpenClosedAndNoPRActive(t *testing.T) {
 
 			wm := &WorktreeManager{
 				repoRoot: tempDir,
-				githubClient: github.NewClientWithRunner(tempDir, func(dir string, name string, args ...string) ([]byte, error) {
+				githubClient: github.NewClientWithRunnerAndCachePath(tempDir, func(dir string, name string, args ...string) ([]byte, error) {
 					return []byte(tc.output), nil
-				}),
+				}, filepath.Join(t.TempDir(), "cache.json")),
 			}
 
 			worktrees, err := wm.ListWorktreesForTUIWithProgress(nil)
@@ -458,9 +458,9 @@ func TestListWorktreesForTUIGitHubFailureIncludesExactCommand(t *testing.T) {
 
 	wm := &WorktreeManager{
 		repoRoot: tempDir,
-		githubClient: github.NewClientWithRunner(tempDir, func(dir string, name string, args ...string) ([]byte, error) {
+		githubClient: github.NewClientWithRunnerAndCachePath(tempDir, func(dir string, name string, args ...string) ([]byte, error) {
 			return nil, errors.New("boom")
-		}),
+		}, filepath.Join(t.TempDir(), "cache.json")),
 	}
 
 	_, err := wm.ListWorktreesForTUIWithProgress(nil)
@@ -504,7 +504,7 @@ func TestListWorktreesForTUIChecksGitHubStatusesInParallel(t *testing.T) {
 	}
 }
 
-func TestListWorktreesForTUISkipsGitHubLookupForCachedMergedBranch(t *testing.T) {
+func TestListWorktreesForTUISkipsGitHubLookupForFreshCachedStatus(t *testing.T) {
 	tempDir, cleanup := setupRepoWithFeatureWorktree(t, "feature-search")
 	defer cleanup()
 
@@ -518,25 +518,79 @@ func TestListWorktreesForTUISkipsGitHubLookupForCachedMergedBranch(t *testing.T)
 		}, cachePath),
 	}
 	commit := currentCommit(t, tempDir, "feature-search")
-	wm.githubClient.RememberMergedPRStatus("feature-search", commit)
+	wm.githubClient.RememberPRStatus("feature-search", commit, "Merged")
 
 	worktrees, err := wm.ListWorktreesForTUIWithProgress(nil)
 	if err != nil {
 		t.Fatalf("ListWorktreesForTUIWithProgress returned error: %v", err)
 	}
 	if calls != 0 {
-		t.Fatalf("expected no GitHub calls for cached merged branch, got %d", calls)
+		t.Fatalf("expected no GitHub calls for fresh cached branch, got %d", calls)
 	}
 
 	for _, wt := range worktrees {
 		if wt.Branch == "feature-search" {
 			if !wt.Merged || wt.PRStatus != "Merged" {
-				t.Fatalf("expected cached merged branch to be marked merged, got %#v", wt)
+				t.Fatalf("expected fresh cached status to be served, got %#v", wt)
 			}
 			return
 		}
 	}
 	t.Fatalf("feature-search worktree was not returned: %#v", worktrees)
+}
+
+func TestListWorktreesForTUIServesStaleCacheAndRefreshesAsync(t *testing.T) {
+	tempDir, cleanup := setupRepoWithFeatureWorktree(t, "feature-search")
+	defer cleanup()
+
+	cachePath := filepath.Join(t.TempDir(), "cache.json")
+	var calls int32
+	wm := &WorktreeManager{
+		repoRoot: tempDir,
+		// A zero TTL/jitter makes every stored entry immediately stale.
+		githubClient: github.NewClientWithRunnerCachePathTTL(tempDir, func(dir string, name string, args ...string) ([]byte, error) {
+			atomic.AddInt32(&calls, 1)
+			return []byte(`[{"state":"MERGED"}]`), nil
+		}, cachePath, 0, 0),
+	}
+	commit := currentCommit(t, tempDir, "feature-search")
+	wm.githubClient.RememberPRStatus("feature-search", commit, "Open")
+
+	worktrees, err := wm.ListWorktreesForTUIWithProgress(nil)
+	if err != nil {
+		t.Fatalf("ListWorktreesForTUIWithProgress returned error: %v", err)
+	}
+
+	// The stale cached value is served immediately without a blocking lookup.
+	var found *Worktree
+	for i := range worktrees {
+		if worktrees[i].Branch == "feature-search" {
+			found = &worktrees[i]
+			break
+		}
+	}
+	if found == nil {
+		t.Fatalf("feature-search worktree was not returned: %#v", worktrees)
+	}
+	if found.PRStatus != "Open" || found.Merged {
+		t.Fatalf("expected stale cached status to be served, got %#v", *found)
+	}
+
+	// The background refresh updates the cache so the next run reads fresh data.
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		status, _ := wm.githubClient.CachedPRStatus("feature-search", commit)
+		if status == "Merged" {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("expected background refresh to update cache to Merged")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if got := atomic.LoadInt32(&calls); got != 1 {
+		t.Fatalf("expected exactly one background GitHub call, got %d", got)
+	}
 }
 
 func setupRepoWithFeatureWorktree(t *testing.T, branch string) (string, func()) {

--- a/pkg/git/worktree_test.go
+++ b/pkg/git/worktree_test.go
@@ -539,6 +539,26 @@ func TestListWorktreesForTUISkipsGitHubLookupForFreshCachedStatus(t *testing.T) 
 	t.Fatalf("feature-search worktree was not returned: %#v", worktrees)
 }
 
+func TestPRStatusCacheSharedAcrossWorktrees(t *testing.T) {
+	tempDir, cleanup := setupRepoWithFeatureWorktree(t, "feature-share")
+	defer cleanup()
+	worktreePath := filepath.Join(filepath.Dir(tempDir), "feature-share")
+
+	cachePath := filepath.Join(t.TempDir(), "cache.json")
+	commit := currentCommit(t, tempDir, "feature-share")
+
+	// Record the status via a client rooted in the main checkout.
+	mainClient := github.NewClientWithRunnerAndCachePath(tempDir, nil, cachePath)
+	mainClient.RememberPRStatus("feature-share", commit, "Merged")
+
+	// A client rooted in the linked worktree must see the same cache entry.
+	worktreeClient := github.NewClientWithRunnerAndCachePath(worktreePath, nil, cachePath)
+	status, state := worktreeClient.CachedPRStatus("feature-share", commit)
+	if state != github.CacheFresh || status != "Merged" {
+		t.Fatalf("expected shared cache hit from worktree, got status %q state %v", status, state)
+	}
+}
+
 func TestListWorktreesForTUIServesStaleCacheAndRefreshesAsync(t *testing.T) {
 	tempDir, cleanup := setupRepoWithFeatureWorktree(t, "feature-search")
 	defer cleanup()

--- a/pkg/github/pr.go
+++ b/pkg/github/pr.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"strings"
 	"sync"
 	"time"
 )
@@ -60,89 +59,14 @@ func runCommandOutput(dir string, name string, args ...string) ([]byte, error) {
 	return cmd.Output()
 }
 
+// GetPRStatus resolves a branch's PR status via GitHub. GitHub is the single
+// source of truth for merge state: git-only heuristics (merge-base ancestry)
+// miss squash-merges and PRs whose remote branch was deleted, which GitHub
+// reports correctly.
 func (c *Client) GetPRStatus(branchName string) string {
 	if branchName == "" || branchName == "master" || branchName == "main" {
 		return "-"
 	}
-
-	// Fast git-based check first
-	status := c.checkBranchStatusWithGit(branchName)
-	if status != "" {
-		return status
-	}
-
-	// Fallback to gh command if git checks are inconclusive
-	return c.checkPRStatusWithGH(branchName)
-}
-
-func (c *Client) checkBranchStatusWithGit(branchName string) string {
-	// Check if remote tracking branch exists
-	cmd := exec.Command("git", "rev-parse", "--verify", "origin/"+branchName)
-	cmd.Dir = c.repoRoot
-	if err := cmd.Run(); err != nil {
-		// Remote branch doesn't exist - could be never pushed or merged and deleted
-		// Only check for "Merged" if we have evidence the branch was previously pushed
-		if c.wasBranchPushed(branchName) && c.isBranchMerged(branchName) {
-			return "Merged"
-		}
-		return "No PR"
-	}
-
-	// Remote branch exists, check if it's ahead/behind
-	return "" // Let gh command handle this case
-}
-
-func (c *Client) isBranchMerged(branchName string) bool {
-	// Get the main branch name
-	mainBranch := c.getMainBranch()
-	if mainBranch == "" {
-		return false
-	}
-
-	// Check if branch commits are in main branch history
-	cmd := exec.Command("git", "merge-base", "--is-ancestor", branchName, mainBranch)
-	cmd.Dir = c.repoRoot
-	return cmd.Run() == nil
-}
-
-func (c *Client) getMainBranch() string {
-	// Try to get default branch from remote
-	cmd := exec.Command("git", "symbolic-ref", "refs/remotes/origin/HEAD")
-	cmd.Dir = c.repoRoot
-	if output, err := cmd.Output(); err == nil {
-		// Output format: refs/remotes/origin/main
-		parts := strings.Split(strings.TrimSpace(string(output)), "/")
-		if len(parts) > 0 {
-			return parts[len(parts)-1]
-		}
-	}
-
-	// Fallback to common names
-	for _, branch := range []string{"main", "master"} {
-		cmd := exec.Command("git", "rev-parse", "--verify", "origin/"+branch)
-		cmd.Dir = c.repoRoot
-		if err := cmd.Run(); err == nil {
-			return branch
-		}
-	}
-
-	return "main" // Default fallback
-}
-
-func (c *Client) wasBranchPushed(branchName string) bool {
-	// Check git reflog for evidence the branch was pushed
-	cmd := exec.Command("git", "reflog", "--grep-reflog=origin/"+branchName, "--all", "--oneline")
-	cmd.Dir = c.repoRoot
-	output, err := cmd.Output()
-	if err != nil {
-		return false
-	}
-
-	// If we find any reflog entries mentioning origin/branchName, it was pushed
-	return len(strings.TrimSpace(string(output))) > 0
-}
-
-func (c *Client) checkPRStatusWithGH(branchName string) string {
 	status, err := c.GetPRStatusFromGH(branchName)
 	if err != nil {
 		return "-"

--- a/pkg/github/pr.go
+++ b/pkg/github/pr.go
@@ -3,10 +3,13 @@ package github
 import (
 	"encoding/json"
 	"fmt"
+	"math/rand"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"sync"
+	"time"
 )
 
 type PR struct {
@@ -42,8 +45,12 @@ func NewClientWithRunner(repoRoot string, runner commandRunner) *Client {
 }
 
 func NewClientWithRunnerAndCachePath(repoRoot string, runner commandRunner, cachePath string) *Client {
+	return NewClientWithRunnerCachePathTTL(repoRoot, runner, cachePath, defaultPRStatusCacheTTL, defaultPRStatusCacheJitter)
+}
+
+func NewClientWithRunnerCachePathTTL(repoRoot string, runner commandRunner, cachePath string, ttl, jitter time.Duration) *Client {
 	client := NewClientWithRunner(repoRoot, runner)
-	client.cache = NewPRStatusCacheWithPath(repoRoot, cachePath)
+	client.cache = NewPRStatusCacheWithOptions(repoRoot, cachePath, ttl, jitter)
 	return client
 }
 
@@ -147,13 +154,20 @@ func PRStatusCommand(branchName string) string {
 	return fmt.Sprintf("gh pr list --head %s --state all --json state --limit 1", branchName)
 }
 
-func (c *Client) CachedMergedPRStatus(branchName, commit string) bool {
-	return c.cache != nil && c.cache.IsMerged(branchName, commit)
+// CachedPRStatus returns the cached PR status for a branch at a commit along
+// with its freshness so callers can decide whether to serve it directly, serve
+// it and refresh asynchronously, or fetch synchronously.
+func (c *Client) CachedPRStatus(branchName, commit string) (string, CacheState) {
+	if c.cache == nil {
+		return "", CacheMiss
+	}
+	return c.cache.Lookup(branchName, commit)
 }
 
-func (c *Client) RememberMergedPRStatus(branchName, commit string) {
+// RememberPRStatus stores the result of a PR status check for later runs.
+func (c *Client) RememberPRStatus(branchName, commit, status string) {
 	if c.cache != nil {
-		c.cache.RememberMerged(branchName, commit)
+		c.cache.Remember(branchName, commit, status)
 	}
 }
 
@@ -188,13 +202,42 @@ func (c *Client) GetPRStatusFromGH(branchName string) (string, error) {
 	}
 }
 
+// CacheState describes how usable a cached PR status is.
+type CacheState int
+
+const (
+	// CacheMiss means there is no usable entry (absent, for a different
+	// commit, or empty); the caller must fetch synchronously.
+	CacheMiss CacheState = iota
+	// CacheFresh means the entry is within its TTL and can be served without
+	// any network call.
+	CacheFresh
+	// CacheStale means the entry has expired; it can still be shown, but the
+	// caller should refresh it asynchronously so the next run is fresh.
+	CacheStale
+)
+
+const (
+	defaultPRStatusCacheTTL    = 10 * time.Minute
+	defaultPRStatusCacheJitter = 5 * time.Minute
+)
+
 type PRStatusCache struct {
 	repoRoot string
 	path     string
+	ttl      time.Duration
+	jitter   time.Duration
+	mu       sync.Mutex
+}
+
+type prStatusEntry struct {
+	Status    string    `json:"status"`
+	Commit    string    `json:"commit"`
+	ExpiresAt time.Time `json:"expiresAt"`
 }
 
 type prStatusCacheFile struct {
-	Repos map[string]map[string]string `json:"repos"`
+	Repos map[string]map[string]prStatusEntry `json:"repos"`
 }
 
 func NewPRStatusCache(repoRoot string) *PRStatusCache {
@@ -206,47 +249,83 @@ func NewPRStatusCache(repoRoot string) *PRStatusCache {
 }
 
 func NewPRStatusCacheWithPath(repoRoot, path string) *PRStatusCache {
+	return NewPRStatusCacheWithOptions(repoRoot, path, defaultPRStatusCacheTTL, defaultPRStatusCacheJitter)
+}
+
+func NewPRStatusCacheWithOptions(repoRoot, path string, ttl, jitter time.Duration) *PRStatusCache {
 	if path == "" {
 		return nil
 	}
 	return &PRStatusCache{
 		repoRoot: repoRoot,
 		path:     path,
+		ttl:      ttl,
+		jitter:   jitter,
 	}
 }
 
-func (c *PRStatusCache) IsMerged(branchName, commit string) bool {
+// Lookup returns the cached PR status for a branch at a given commit along with
+// its freshness. Entries recorded for a different commit are treated as a miss
+// so that pushing new work always re-checks the PR.
+func (c *PRStatusCache) Lookup(branchName, commit string) (string, CacheState) {
 	if c == nil || branchName == "" || commit == "" {
-		return false
+		return "", CacheMiss
 	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
 	cacheFile, err := c.load()
 	if err != nil {
-		return false
+		return "", CacheMiss
 	}
-	return cacheFile.Repos[c.repoRoot][branchName] == commit
+	entry, ok := cacheFile.Repos[c.repoRoot][branchName]
+	if !ok || entry.Commit != commit || entry.Status == "" {
+		return "", CacheMiss
+	}
+	if time.Now().After(entry.ExpiresAt) {
+		return entry.Status, CacheStale
+	}
+	return entry.Status, CacheFresh
 }
 
-func (c *PRStatusCache) RememberMerged(branchName, commit string) {
-	if c == nil || branchName == "" || commit == "" {
+// Remember stores the PR status for a branch at a commit, stamping it with a
+// jittered expiry so entries written together do not all go stale on the same
+// later run.
+func (c *PRStatusCache) Remember(branchName, commit, status string) {
+	if c == nil || branchName == "" || commit == "" || status == "" {
 		return
 	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
 
 	cacheFile, err := c.load()
 	if err != nil {
-		cacheFile = prStatusCacheFile{Repos: make(map[string]map[string]string)}
+		cacheFile = prStatusCacheFile{Repos: make(map[string]map[string]prStatusEntry)}
 	}
 	if cacheFile.Repos == nil {
-		cacheFile.Repos = make(map[string]map[string]string)
+		cacheFile.Repos = make(map[string]map[string]prStatusEntry)
 	}
 	if cacheFile.Repos[c.repoRoot] == nil {
-		cacheFile.Repos[c.repoRoot] = make(map[string]string)
+		cacheFile.Repos[c.repoRoot] = make(map[string]prStatusEntry)
 	}
-	cacheFile.Repos[c.repoRoot][branchName] = commit
+	cacheFile.Repos[c.repoRoot][branchName] = prStatusEntry{
+		Status:    status,
+		Commit:    commit,
+		ExpiresAt: time.Now().Add(c.entryLifetime()),
+	}
 	_ = c.save(cacheFile)
 }
 
+// entryLifetime is the base TTL plus a random jitter in [0, jitter).
+func (c *PRStatusCache) entryLifetime() time.Duration {
+	if c.jitter <= 0 {
+		return c.ttl
+	}
+	return c.ttl + time.Duration(rand.Int63n(int64(c.jitter)))
+}
+
 func (c *PRStatusCache) load() (prStatusCacheFile, error) {
-	cacheFile := prStatusCacheFile{Repos: make(map[string]map[string]string)}
+	cacheFile := prStatusCacheFile{Repos: make(map[string]map[string]prStatusEntry)}
 	data, err := os.ReadFile(c.path)
 	if err != nil {
 		return cacheFile, err
@@ -255,7 +334,7 @@ func (c *PRStatusCache) load() (prStatusCacheFile, error) {
 		return cacheFile, err
 	}
 	if cacheFile.Repos == nil {
-		cacheFile.Repos = make(map[string]map[string]string)
+		cacheFile.Repos = make(map[string]map[string]prStatusEntry)
 	}
 	return cacheFile, nil
 }

--- a/pkg/github/pr.go
+++ b/pkg/github/pr.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"sync"
 	"time"
 )
@@ -28,7 +29,7 @@ func NewClient(repoRoot string) *Client {
 	return &Client{
 		repoRoot: repoRoot,
 		runner:   runCommandOutput,
-		cache:    NewPRStatusCache(repoRoot),
+		cache:    NewPRStatusCache(repoIdentity(repoRoot)),
 	}
 }
 
@@ -39,7 +40,7 @@ func NewClientWithRunner(repoRoot string, runner commandRunner) *Client {
 	return &Client{
 		repoRoot: repoRoot,
 		runner:   runner,
-		cache:    NewPRStatusCache(repoRoot),
+		cache:    NewPRStatusCache(repoIdentity(repoRoot)),
 	}
 }
 
@@ -49,7 +50,7 @@ func NewClientWithRunnerAndCachePath(repoRoot string, runner commandRunner, cach
 
 func NewClientWithRunnerCachePathTTL(repoRoot string, runner commandRunner, cachePath string, ttl, jitter time.Duration) *Client {
 	client := NewClientWithRunner(repoRoot, runner)
-	client.cache = NewPRStatusCacheWithOptions(repoRoot, cachePath, ttl, jitter)
+	client.cache = NewPRStatusCacheWithOptions(repoIdentity(repoRoot), cachePath, ttl, jitter)
 	return client
 }
 
@@ -57,6 +58,31 @@ func runCommandOutput(dir string, name string, args ...string) ([]byte, error) {
 	cmd := exec.Command(name, args...)
 	cmd.Dir = dir
 	return cmd.Output()
+}
+
+// repoIdentity returns a stable cache key for a repository that is the same for
+// its main checkout and every linked worktree. The git common directory (e.g.
+// /path/to/repo/.git) is shared across all worktrees, whereas the working-tree
+// root differs per worktree — keying on the latter would give each worktree its
+// own cache. Falls back to repoRoot when the git dir cannot be resolved.
+func repoIdentity(repoRoot string) string {
+	cmd := exec.Command("git", "rev-parse", "--git-common-dir")
+	cmd.Dir = repoRoot
+	output, err := cmd.Output()
+	if err != nil {
+		return repoRoot
+	}
+	dir := strings.TrimSpace(string(output))
+	if dir == "" {
+		return repoRoot
+	}
+	if !filepath.IsAbs(dir) {
+		dir = filepath.Join(repoRoot, dir)
+	}
+	if abs, err := filepath.Abs(dir); err == nil {
+		return abs
+	}
+	return dir
 }
 
 // GetPRStatus resolves a branch's PR status via GitHub. GitHub is the single


### PR DESCRIPTION
The worktree PR status cache previously only remembered branches whose
PRs had already merged, so every other branch (open, closed, no PR) ran
`gh pr list` on every TUI load, and the cache file was never even created
until a merge was seen.

Cache the result of the status check for all branches instead. Each entry
stores the resolved status keyed by branch + commit and carries a jittered
expiry (base TTL + random jitter) so entries written together don't all go
stale on the same later run.

Reads become stale-while-revalidate:
- Fresh entry: served from the hot path with no network call.
- Stale entry: served immediately, then refreshed in a background
  goroutine so the next run reads fresh data.
- Miss (absent or a different commit): fetched synchronously as before.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LxEHyJmtwG7yYcQtYTbX9R